### PR TITLE
Fix DNA encoding bug

### DIFF
--- a/src/exabiome/sequence/convert.py
+++ b/src/exabiome/sequence/convert.py
@@ -351,12 +351,12 @@ def _get_DNA_map():
     For this to work, bases need to be ordered as they are below
 
     '''
-    chars = ('ACYWSKDVN'
-             'TGRWSMHBN')
+    chars = ('ACYWSKDVNTGRMHB')
     basemap = np.zeros(128, dtype=np.uint8)
     for i, c in reversed(list(enumerate(chars))):  # reverse so we store the lowest for self-complementary codes
         basemap[ord(c)] = i
         basemap[ord(c.lower())] = i
+    basemap[ord('x')] = basemap[ord('X')] = basemap[ord('n')]
     return chars, basemap
 
 


### PR DESCRIPTION
There were duplicate characters in the DNA characters string, resulting in W, S, and N getting reverse-complemented to character 0. This fix ensures that W, S, and N will get reverse complemented to themselves.