### PR TITLE
Add bottleneck at the end of ResNet features

### DIFF
--- a/src/exabiome/nn/models/resnet.py
+++ b/src/exabiome/nn/models/resnet.py
@@ -111,6 +111,21 @@ class Bottleneck(nn.Module):
         return out
 
 
+class FeatureReduction(nn.Module):
+
+    def __init__(self, inplanes, planes):
+        super(FeatureReduction, self).__init__()
+        self.conv1 = conv1x1(inplanes, planes)
+        self.bn1 = nn.BatchNorm1d(planes)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+        return out
+
+
 class ResNet(AbstractLit):
 
     def __init__(self, hparams):
@@ -159,12 +174,16 @@ class ResNet(AbstractLit):
                                        dilate=replace_stride_with_dilation[1])
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
                                        dilate=replace_stride_with_dilation[2])
+
+        n_output_channels = 64 * block.expansion
+        self.bottleneck = FeatureReduction(512 * block.expansion, n_output_channels)
+
         self.avgpool = nn.AdaptiveAvgPool1d(1)
 
         if hparams.tgt_tax_lvl == 'all':
-            self.fc = HierarchicalClassifier(512 * block.expansion, hparams.n_taxa_all)
+            self.fc = HierarchicalClassifier(n_output_channels, hparams.n_taxa_all)
         else:
-            self.fc = nn.Linear(512 * block.expansion, hparams.n_outputs)
+            self.fc = nn.Linear(n_output_channels, hparams.n_outputs)
 
         for m in self.modules():
             if isinstance(m, nn.Conv1d):
@@ -259,6 +278,8 @@ class ResNet(AbstractLit):
         x = self.layer2(x)
         x = self.layer3(x)
         x = self.layer4(x)
+
+        x = self.bottleneck(x)
 
         x = self.avgpool(x)
         x = torch.flatten(x, 1)

--- a/src/exabiome/nn/models/resnet.py
+++ b/src/exabiome/nn/models/resnet.py
@@ -423,6 +423,7 @@ class ResNetFeatures(nn.Module):
                 'layer2',
                 'layer3',
                 'layer4',
+                'bottleneck',
                 'avgpool')
 
     def __init__(self, resnet):
@@ -443,6 +444,8 @@ class ResNetFeatures(nn.Module):
         x = self.layer2(x)
         x = self.layer3(x)
         x = self.layer4(x)
+
+        x = self.bottleneck(x)
 
         x = self.avgpool(x)
         x = torch.flatten(x, 1)

--- a/src/exabiome/nn/models/resnet.py
+++ b/src/exabiome/nn/models/resnet.py
@@ -175,8 +175,12 @@ class ResNet(AbstractLit):
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
                                        dilate=replace_stride_with_dilation[2])
 
-        n_output_channels = 64 * block.expansion
-        self.bottleneck = FeatureReduction(512 * block.expansion, n_output_channels)
+        n_output_channels = 512 * block.expansion
+        if hparams.bottleneck:
+            self.bottleneck = FeatureReduction(n_output_channels, 64 * block.expansion)
+            n_output_channels = 64 * block.expansion
+        else:
+            self.bottleneck = None
 
         self.avgpool = nn.AdaptiveAvgPool1d(1)
 
@@ -279,7 +283,8 @@ class ResNet(AbstractLit):
         x = self.layer3(x)
         x = self.layer4(x)
 
-        x = self.bottleneck(x)
+        if self.bottleneck is not None:
+            x = self.bottleneck(x)
 
         x = self.avgpool(x)
         x = torch.flatten(x, 1)
@@ -445,7 +450,8 @@ class ResNetFeatures(nn.Module):
         x = self.layer3(x)
         x = self.layer4(x)
 
-        x = self.bottleneck(x)
+        if self.bottleneck is not None:
+            x = self.bottleneck(x)
 
         x = self.avgpool(x)
         x = torch.flatten(x, 1)

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -298,6 +298,7 @@ def run_lightning(argv=None):
     with open(output('args.pkl'), 'wb') as f:
         pickle.dump(args, f)
 
+    checkpoint = None
     if args.init is not None:
         checkpoint = args.init
         link_dest = 'init.ckpt'

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -82,12 +82,6 @@ def process_config(conf_path, args=None):
         conf_val = config.pop(k, v.get('default', None))
         setattr(args, k, conf_val)
 
-    # set number if input channels
-    input_nc = 18
-    if args.protein:
-        input_nc = 26
-    args.input_nc = input_nc
-
     # classify by default
     if args.manifold == args.classify == False:
         args.classify = True
@@ -175,6 +169,9 @@ def process_args(args=None, return_io=False):
     # if classification problem, use the number of taxa as the number of outputs
     if args.classify:
         args.n_outputs = len(data_mod.dataset.taxa_labels)
+
+    args.input_nc = len(data_mod.dataset.vocab)
+
     model = process_model(args, taxa_table=data_mod.dataset.difile.taxa_table)
 
     if args.weighted is not None:

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -55,6 +55,7 @@ def get_conf_args():
         'fwd_only': dict(action='store_true', help='use forward strand of sequences only', default=False),
         'classify': dict(action='store_true', help='run a classification problem', default=False),
         'manifold': dict(action='store_true', help='run a manifold learning problem', default=False),
+        'bottleneck': dict(action='store_true', help='add bottleneck layer at the end of ResNet features', default=True),
         'tgt_tax_lvl': dict(choices=DeepIndexFile.taxonomic_levels, metavar='LEVEL', default='species',
                            help='the taxonomic level to predict. choices are phylum, class, order, family, genus, species'),
     }


### PR DESCRIPTION
- Bottleneck will downsize from `512 * block.expansion` to `64 * block.expansion`
- this can be turned off by setting `bottleneck: false` in config file