### PR TITLE
Add missing wait flag for cori slurmjob

### DIFF
--- a/src/exabiome/run/cori.py
+++ b/src/exabiome/run/cori.py
@@ -5,6 +5,7 @@ class SlurmJob(AbstractJob):
 
     directive = 'SBATCH'
     queue_flag = 'q'
+    wait_flag = 'W'
     project_flag = 'A'
     time_flag = 't'
     output_flag = 'o'


### PR DESCRIPTION
I assume it is this flag: https://slurm.schedmd.com/sbatch.html#OPT_wait