### PR TITLE
Reduce memory usage for chunking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hdmf==3.1.1
-pytorch_lightning==1.4.3
+pytorch_lightning==1.5.8
 torch==1.7.1
 torch_optimizer==0.1.0

--- a/src/exabiome/nn/__init__.py
+++ b/src/exabiome/nn/__init__.py
@@ -1,1 +1,1 @@
-from .loader import get_loader, train_test_loaders, SeqDataset
+from .loader import get_loader, train_test_loaders

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -47,19 +47,35 @@ def dataset_stats(argv=None):
 
     parser =  argparse.ArgumentParser()
     parser.add_argument('input', type=str, help='the HDF5 DeepIndex file')
-    parser.add_argument('-L', '--lazy', action='store_true', default=False, help='lazy load sequences')
     add_dataset_arguments(parser)
     test_group = parser.add_argument_group('Test reading')
     test_group.add_argument('-T', '--test_read', default=False, action='store_true', help='test reading an element')
-    test_group.add_argument('-s', '--seed', type=parse_seed, default=None, help='seed for an 80/10/10 split before reading an element')
+    test_group.add_argument('-L', '--lightning', default=False, action='store_true', help='test reading with DeepIndexDataModule')
+    test_group.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=0)
+    test_group.add_argument('-y', '--pin_memory', action='store_true', default=False, help='pin memory when loading data')
+    test_group.add_argument('-f', '--shuffle', action='store_true', default=False, help='shuffle batches when training')
+    test_group.add_argument('-s', '--seed', type=parse_seed, default='', help='seed for an 80/10/10 split before reading an element')
     test_group.add_argument('-l', '--load', action='store_true', default=False, help='load data into memory before running training loop')
     test_group.add_argument('-m', '--output_map', nargs=2, type=str, help='print the outputs map from one taxonomic level to another', default=None)
 
 
     args = parser.parse_args(argv)
-    before = time()
-    dataset = LazySeqDataset(path=args.input, hparams=args, keep_open=True, lazy_chunk=args.lazy)
-    print(f'Took {time() - before} seconds to open {args.input}')
+    if args.lightning:
+        args.batch_size = 1
+        args.downsample = False
+        args.loader_kwargs = dict()
+        before = time()
+        data_mod = DeepIndexDataModule(hparams=args, keep_open=True)
+        after = time()
+        dataset = data_mod.dataset
+    else:
+        before = time()
+        print('hparams', args)
+        dataset = LazySeqDataset(path=args.input, hparams=args, keep_open=True, lazy_chunk=True)
+        dataset.load(sequence=False)
+        after = time()
+
+    print(f'Took {after - before} seconds to open {args.input}')
     difile = dataset.difile
 
     n_taxa = len(difile.taxa_table)
@@ -69,6 +85,7 @@ def dataset_stats(argv=None):
     n_disc = difile.n_discarded
     wlen = args.window
     step = args.step
+
     if wlen is not None:
         print((f'Splitting {n_seqs} sequences (from {n_taxa} species) into {wlen} '
                f'bp windows every {step} bps produces {n_samples} samples '
@@ -76,18 +93,32 @@ def dataset_stats(argv=None):
     else:
         print(f'Found {n_seqs} sequences across {n_taxa} species. {n_samples} total samples')
 
+
     if args.test_read:
-        print("Attempting to read training data")
-        tr, va, te = train_test_loaders(dataset, random_state=args.seed, downsample=None)
+        dataset.close()
         from tqdm import tqdm
+        print("Attempting to read training data")
+        if args.lightning:
+            tr = data_mod.train_dataloader()
+        else:
+            dataset.set_subset(train=True)
+            kwargs = {'collate_fn': get_collater(dataset), 'shuffle': True, 'batch_size': 1}
+            tr = DataLoader(dataset, **kwargs)
         for i in tqdm(tr):
             continue
+
         print("Attempting to read validation data")
+        if args.lightning:
+            va = data_mod.val_dataloader()
+        else:
+            dataset.set_subset(validate=True)
+            kwargs.pop('shuffle')
+            va = DataLoader(dataset, **kwargs)
         for i in tqdm(va):
             continue
-        print("Attempting to read testing data")
-        for i in tqdm(te):
-            continue
+        #print("Attempting to read testing data")
+        #for i in tqdm(te):
+        #    continue
     if args.output_map is not None:
         tl1, tl2 = args.output_map
         ret = difile.taxa_table.get_outputs_map(tl1, tl2)
@@ -521,6 +552,18 @@ def train_test_loaders(dataset, random_state=None, downsample=None, **kwargs):
 
     return (tr_dl, va_dl, te_dl)
 
+
+def get_collater(dataset):
+    if dataset.tnf:
+        return TnfCollater(dataset.vocab)
+    elif dataset.manifold:
+        return DistanceCollater(dataset.distances, seq_collater=collater)
+    elif dataset.graph:
+        return GraphCollater(dataset.node_ids, seq_collater=collater)
+    else:
+        return SeqCollater(dataset.padval)
+
+
 def get_loader(dataset, distances=False, graph=False, **kwargs):
     """
     Return a DataLoader that loads data from the given Dataset
@@ -553,15 +596,15 @@ class DeepIndexDataModule(pl.LightningDataModule):
     def __init__(self, hparams, inference=False, keep_open=False):
         super().__init__()
 
-        kwargs = dict(random_state=hparams.seed,
-                      batch_size=hparams.batch_size,
-                      downsample=hparams.downsample)
+        kwargs = dict(batch_size=hparams.batch_size)
+
         if inference:
             hparams.manifold = False
             hparams.graph = False
             self.dataset = LazySeqDataset(hparams=hparams, keep_open=keep_open)
             kwargs['shuffle'] = False
         else:
+            print('hparams', hparams)
             self.dataset = LazySeqDataset(hparams=hparams, keep_open=keep_open)
             self.dataset.load(sequence=hparams.load)
             kwargs['pin_memory'] = False
@@ -574,25 +617,30 @@ class DeepIndexDataModule(pl.LightningDataModule):
             kwargs['worker_init_fn'] = self.dataset.worker_init
             kwargs['persistent_workers'] = True
 
-        self._loader_kwargs = kwargs
-        self.loaders = None
+        kwargs['collate_fn'] = get_collater(self.dataset)
 
-    def _check_loaders(self):
-        if self.loaders is None:
-            tr, te, va = train_test_loaders(self.dataset, **self._loader_kwargs)
-            self.loaders = {'train': tr, 'test': te, 'validate': va}
+        self._loader_kwargs = kwargs
+        print(self._loader_kwargs)
+
+    def _check_close(self):
+        if self._loader_kwargs.get('num_workers', None) not in (None, 0):
+            self.dataset.close()
 
     def train_dataloader(self):
-        self._check_loaders()
-        return self.loaders['train']
+        self.dataset.open()
+        self.dataset.set_subset(train=True)
+        self._check_close()
+        return DataLoader(self.dataset, **self._loader_kwargs)
 
     def val_dataloader(self):
-        self._check_loaders()
-        return self.loaders['validate']
+        self.dataset.open()
+        self.dataset.set_subset(validate=True)
+        self._check_close()
+        kwargs = self._loader_kwargs.copy()
+        kwargs.pop('shuffle', False)
+        return DataLoader(self.dataset, **kwargs)
 
     def test_dataloader(self):
-        #self._check_loaders()
-        #return self.loaders['test']
         return None
 
 
@@ -713,18 +761,19 @@ class LazySeqDataset(Dataset):
 
         self._label_dtype = torch.int64
 
+        self._train_subset = False
+        self._validate_subset = False
+        self._test_subset = False
+
         # open to get dataset length
         self.open()
-        self.__len = len(self.difile)
-        self.__sample_labels = None
         if self.__lazy_chunk:
             counts = self.difile.lut.copy()
             counts[1:] = counts[1:] - counts[:-1]
             self.taxa_counts = np.bincount(self.orig_difile.labels, weights=counts).astype(int)
             self.taxa_labels = np.arange(len(self.taxa_counts))
         else:
-            self.__sample_labels = self.difile.labels
-            self.taxa_labels, self.taxa_counts = np.unique(self.__sample_labels, return_counts=True)
+            self.taxa_labels, self.taxa_counts = np.unique(self.difile.labels, return_counts=True)
         self.label_names = self.difile.get_label_classes()
 
         self.vocab = np.chararray.upper(self.orig_difile.seq_table['sequence'].target.elements[:].astype('U1'))
@@ -785,18 +834,6 @@ class LazySeqDataset(Dataset):
         if not keep_open:
             self.close()
 
-    @property
-    def sample_labels(self):
-        if self.__lazy_chunk:
-            counts = self.difile.lut.copy()
-            counts[1:] = counts[1:] - counts[:-1]
-            ret = np.repeat(self.orig_difile.labels, counts)
-            if self.revcomp:
-                ret = np.repeat(ret, 2)
-            return ret
-        else:
-            return self.__sample_labels
-
     def close(self):
         if self.io is not None:
             self.io.close()
@@ -829,14 +866,7 @@ class LazySeqDataset(Dataset):
         if self.revcomp:
             self.set_revcomp()
 
-        #TODO    fill this in
-        if self.train_subset:
-            self.set_subset()
-        elif self.val_subset:
-            self.set_subset(validate=True)
-        elif self.test_subset:
-            pass
-
+        self._set_subset(train=self._train_subset, validate=self._validate_subset, test=self._test_subset)
 
     def worker_init(self, worker_id):
         # September 15, 2021, ajtritt
@@ -859,22 +889,33 @@ class LazySeqDataset(Dataset):
     def set_revcomp(self, revcomp=True):
         self.difile = RevCompFilter(self.difile)
 
-    def set_subset(self, validate=False, test=False):
-        counts = self.difile.get_counts()
-        val_counts = np.round(self.val_frac * counts).astype(int)
-        train_counts = counts - val_counts
-        if validate:
-            self.difile = LazySubset(self.difile, val_counts, starts=train_counts)
-        elif test:
-            raise ValueError("Cannot do this yet, and I may never do it!")
+    def set_subset(self, train=False, validate=False, test=False):
+        self._train_subset = train
+        self._validate_subset = validate
+        self._test_subset = test
+        if self.difile is not None:
+            self._set_subset(train=self._train_subset, validate=self._validate_subset, test=self._test_subset)
+
+    def _set_subset(self, train=False, validate=False, test=False):
+        if all((not train, not validate, not test)):
+            self.difile.set_subset(None, None)
         else:
-            self.difile = LazySubset(self.difile, train_counts)
+            counts = self.difile.get_counts(orig=True)
+            val_counts = np.round(self.val_frac * counts).astype(int)
+            train_counts = counts - val_counts
+            if validate:
+                self.difile.set_subset(val_counts, self.hparams.seed, starts=train_counts)
+            elif test:
+                raise ValueError("Cannot do this yet, and I may never do it, since we use held-out genomes for testing")
+            else:
+                self.difile.set_subset(train_counts, self.hparams.seed)
+        self.__len = len(self.difile)
 
     def set_ohe(self, ohe=True):
         self.__ohe = ohe
 
     def __len__(self):
-        return self.__len # len(self.difile)
+        return len(self.difile) if self.difile is not None else self.__len
 
     @staticmethod
     def _to_numpy(data):

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -59,7 +59,7 @@ def dataset_stats(argv=None):
     args = parser.parse_args(argv)
     before = time()
     dataset = LazySeqDataset(path=args.input, hparams=args, keep_open=True, lazy_chunk=args.lazy)
-    print(f'Took {int(time() - before)} seconds to open {args.input}')
+    print(f'Took {time() - before} seconds to open {args.input}')
     difile = dataset.difile
 
     n_taxa = len(difile.taxa_table)
@@ -832,7 +832,7 @@ class LazySeqDataset(Dataset):
     def load(self, sequence=False, device=None):
         _load = lambda x: x[:]
         self.orig_difile.seq_table['id'].transform(_load)
-        self.orig_difile.seq_table['length'].transform(_load)
+        self.orig_difile.seq_table['length'].transform(lambda x: x[:].astype(int))
         self.orig_difile.seq_table['sequence_index'].transform(_load)
         if sequence:
             self.orig_difile.seq_table['sequence_index'].target.transform(_load)

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -779,7 +779,8 @@ class LazySeqDataset(Dataset):
         kwargs.setdefault('graph', False)
         kwargs.setdefault('load', False)
         kwargs.setdefault('ohe', False)
-        kwargs.setdefault('weighted', False)
+        kwargs.setdefault('tnf', False)
+        kwargs.setdefault('weighted', None)
 
         self.comm = kwargs.pop('comm', None)
 

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -65,11 +65,13 @@ def dataset_stats(argv=None):
     n_seqs = len(difile.seq_table)
 
     n_samples = len(dataset)
+    n_disc = difile.n_discarded
     wlen = args.window
     step = args.step
     if wlen is not None:
         print((f'Splitting {n_seqs} sequences (from {n_taxa} species) into {wlen} '
-               f'bp windows every {step} bps produces {n_samples} samples'))
+               f'bp windows every {step} bps produces {n_samples} samples '
+               f'(after discarding {n_disc} samples).'))
     else:
         print(f'Found {n_seqs} sequences across {n_taxa} species. {n_samples} total samples')
 

--- a/src/exabiome/nn/models/lit.py
+++ b/src/exabiome/nn/models/lit.py
@@ -7,10 +7,6 @@ import torch
 import argparse
 from time import time
 
-#from .. import SeqDataset
-#from hdmf.common import get_hdf5io
-from ..loader import process_dataset
-
 from ...sequence import WindowChunkedDIFile
 from ..loss import DistMSELoss, EuclideanMAELoss, HyperbolicMAELoss
 

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -214,6 +214,7 @@ def process_args(args=None, return_io=False):
 
     if args.num_workers > 0:
         data_mod.dataset.close()
+        #pass
 
     targs = dict(
         max_epochs=args.epochs,
@@ -242,7 +243,11 @@ def process_args(args=None, return_io=False):
 
     if env is not None:
         global RANK
-        RANK = env.global_rank()
+        try:
+            RANK = env.global_rank()
+        except:
+            print(">>> Could not get global rank -- setting RANK to 0", file=sys.stderr)
+            RANK = 0
 
     if targs['gpus'] is not None:
         if targs['gpus'] == 1:
@@ -373,6 +378,7 @@ def run_lightning(argv=None):
         callbacks=callbacks,
         logger = CSVLogger(save_dir=output('logs')),
         profiler = "simple",
+        num_sanity_val_steps = 0,
     )
     targs.update(addl_targs)
 

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -273,8 +273,8 @@ def process_args(args=None, return_io=False):
         )
 
     if args.sanity:
-        targs['limit_train_batches'] = 40
-        targs['limit_val_batches'] = 5
+        targs['limit_train_batches'] = 400
+        targs['limit_val_batches'] = 50
 
     if args.lr_find:
         targs['auto_lr_find'] = True

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -391,13 +391,13 @@ def run_lightning(argv=None):
         targs['fast_dev_run'] = 10
 
     print0('Trainer args:', targs, file=sys.stderr)
-    print0('DataLoader args:', data_model._loader_kwargs, file=sys.stderr)
+    print0('DataLoader args:', data_mod._loader_kwargs, file=sys.stderr)
     print0('Model:\n', model, file=sys.stderr)
 
     trainer = Trainer(**targs)
 
     if args.debug:
-        print_dataloader(data_mod.test_dataloader())
+        #print_dataloader(data_mod.test_dataloader())
         print_dataloader(data_mod.train_dataloader())
         print_dataloader(data_mod.val_dataloader())
 

--- a/src/exabiome/nn/utils.py
+++ b/src/exabiome/nn/utils.py
@@ -2,7 +2,6 @@ from argparse import Namespace
 import sys
 import os
 
-from .loader import read_dataset
 from . import models
 
 from ..utils import check_directory

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -683,7 +683,7 @@ class LazyWindowChunkedDIFile(DIFileFilter):
         self.window = window
         self.step = step
         self.difile = difile
-        self.lengths = difile.seq_table['length']
+        self.lengths = difile.seq_table['length'].data
         self.labels = LabelComputer(self.lut, difile.labels)
         self.n_discarded = int(self.lut[-1] / frac_good - self.lut[-1])
 

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -531,12 +531,16 @@ class AbstractChunkedDIFile(DIFileFilter):
     An abstract class for chunking sequences from a DeepIndexFile
     """
 
-    def __init__(self, difile, seq_idx, start, end, labels):
+    def __init__(self, difile, seq_idx, start, end, labels, frac_good=None):
         super().__init__(difile)
         self.seq_idx = np.asarray(seq_idx)
         self.start = np.asarray(start)
         self.end = np.asarray(end)
         self.labels = np.asarray(labels)
+        if frac_good is not None:
+            self.n_discarded = int(len(seq_idx) / frac_good - len(seq_idx))
+        else:
+            self.n_discarded = -1
 
     def __len__(self):
         return len(self.seq_idx)
@@ -563,11 +567,11 @@ class WindowChunkedDIFile(AbstractChunkedDIFile):
     """
 
     def __init__(self, difile, wlen, step=None, min_seq_len=100):
-        seq_idx, chunk_start, chunk_end, labels = chunk_sequence(difile, wlen, step=step, min_seq_len=min_seq_len)
+        seq_idx, chunk_start, chunk_end, labels, frac_good = chunk_sequence(difile, wlen, step=step, min_seq_len=min_seq_len)
         self.wlen = wlen
         self.step = step
         self.min_seq_len = min_seq_len
-        super().__init__(difile, seq_idx, chunk_start, chunk_end, labels)
+        super().__init__(difile, seq_idx, chunk_start, chunk_end, labels, frac_good)
 
 def chunk_sequence(difile, wlen, step=None, min_seq_len=100):
     """
@@ -614,7 +618,7 @@ def chunk_sequence(difile, wlen, step=None, min_seq_len=100):
     seq_idx = seq_idx[mask]
     chunk_start = chunk_start[mask]
     chunk_end = chunk_end[mask]
-    return seq_idx, chunk_start, chunk_end, labels
+    return seq_idx, chunk_start, chunk_end, labels, mask.mean()
 
 
 


### PR DESCRIPTION
Chunk start/end coordinates are now computed on the flow. This is handled by `LazyWindowChunkedDIFile`. Chunks are computed by 
1. Calculate the number of chunks in each sequence.
2. Create a look up table that maps chunk index to sequence ID
3. To get chunk `i`, look up sequence ID using LUT from step 2.
4. Use LUT again to determine `j`, the chunk index within the sequence
5. Compute chunk _start_ as `j * S` and chunk _end_ as `min(j * S + W, L)`, where `S` is the step size, `W` is the window size and `L` is the length of the sequence