### PR TITLE
Add space-efficient sampler

### DIFF
--- a/src/exabiome/__init__.py
+++ b/src/exabiome/__init__.py
@@ -46,6 +46,7 @@ def main():
             'probe': Command('nn.probe.probe', 'Probe the environment of the system'),
             'model-info': Command('nn.train.get_model_info', 'Construct and print info about model'),
             'to-onnx': Command('nn.deploy.to_onnx', 'Convert checkpoint to ONNX format'),
+            'bm-dset': Command('nn.train.benchmark_pass', 'Read dataset and run a few batches for bencharking'),
         },
         'Inference and model assessment': {
             'infer': Command('nn.infer.run_inference', 'Run inference using PyTorch'),

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -726,13 +726,11 @@ class DeepIndexDataModule(pl.LightningDataModule):
             self.dataset = LazySeqDataset(hparams=hparams, keep_open=keep_open)
             self.dataset.load(sequence=hparams.load)
             kwargs['pin_memory'] = hparams.pin_memory
-            #kwargs['shuffle'] = hparams.shuffle
             kwargs['shuffle'] = False
-            if hparams.shuffle and False:
-                self.dataset.set_subset(train=True)
-                train_len = len(self.dataset)
-                self.dataset.set_subset()
-                kwargs['sampler'] = WORSampler(train_len, rng=seed, rank=rank, size=size)
+            self.dataset.set_subset(train=True)
+            train_len = len(self.dataset)
+            self.dataset.set_subset()
+            kwargs['sampler'] = WORSampler(train_len, rng=seed, rank=rank, size=size)
 
         kwargs.update(hparams.loader_kwargs)
         kwargs['num_workers'] = hparams.num_workers

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -280,7 +280,6 @@ class TrainingSeqCollater:
                 maxlen = X.shape[l_idx]
         X_ret = list()
         y_ret = list()
-        idx_ret = list()
         for i, X, y, seq_id in samples:
             dif = maxlen - X.shape[l_idx]
             X_ = X
@@ -288,11 +287,9 @@ class TrainingSeqCollater:
                 X_ = F.pad(X, (0, dif), value=self.padval)
             X_ret.append(X_)
             y_ret.append(y)
-            idx_ret.append(int(i))
         X_ret = torch.stack(X_ret)
         y_ret = torch.stack(y_ret)
-        idx_ret = torch.tensor(idx_ret)
-        return (X_ret, y_ret, idx_ret)
+        return (X_ret, y_ret)
 
 
 def _check_collater(padval, seq_collater):

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -7,7 +7,8 @@ import pytorch_lightning as pl
 import torch.nn.functional as F
 import torch
 import numpy as np
-from torch.utils.data import DataLoader, Dataset, SubsetRandomSampler, Subset
+from torch.utils.data import DataLoader, Dataset, Subset, Sampler
+
 from sklearn.model_selection import train_test_split
 from sklearn.utils import check_random_state
 from hdmf.common import get_hdf5io
@@ -65,11 +66,13 @@ def dataset_stats(argv=None):
     add_dataset_arguments(parser)
     test_group = parser.add_argument_group('Test reading')
     test_group.add_argument('-T', '--test_read', default=False, action='store_true', help='test reading an element')
+    test_group.add_argument('--mem', default=False, action='store_true', help='print memory usage before and after loading')
     test_group.add_argument('-L', '--lightning', default=False, action='store_true', help='test reading with DeepIndexDataModule')
     test_group.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=0)
     test_group.add_argument('-y', '--pin_memory', action='store_true', default=False, help='pin memory when loading data')
     test_group.add_argument('-f', '--shuffle', action='store_true', default=False, help='shuffle batches when training')
     test_group.add_argument('-b', '--batch_size', type=int, help='the number of workers to load data with', default=1)
+    test_group.add_argument('-N', '--num_batches', type=int, help='the number of batches to load when testing read', default=None)
     test_group.add_argument('-s', '--seed', type=parse_seed, default='', help='seed for an 80/10/10 split before reading an element')
     test_group.add_argument('-l', '--load', action='store_true', default=False, help='load data into memory before running training loop')
     test_group.add_argument('-m', '--output_map', nargs=2, type=str, help='print the outputs map from one taxonomic level to another', default=None)
@@ -79,11 +82,13 @@ def dataset_stats(argv=None):
     if args.lightning:
         args.downsample = False
         args.loader_kwargs = dict()
-        print_mem('before DeepIndexDataModule')
+        if args.mem:
+            print_mem('before DeepIndexDataModule')
         before = time()
         data_mod = DeepIndexDataModule(hparams=args, keep_open=True)
         after = time()
-        print_mem('after DeepIndexDataModule ')
+        if args.mem:
+            print_mem('after DeepIndexDataModule ')
         dataset = data_mod.dataset
     else:
         before = time()
@@ -116,15 +121,25 @@ def dataset_stats(argv=None):
         from tqdm import tqdm
         print("Attempting to read training data")
         if args.lightning:
-            print_mem('before train_dataloader   ')
+            if args.mem:
+                print_mem('before train_dataloader   ')
             tr = data_mod.train_dataloader()
-            print_mem('after train_dataloader    ')
+            if args.mem:
+                print_mem('after train_dataloader    ')
         else:
             dataset.set_subset(train=True)
             kwargs = {'collate_fn': get_collater(dataset), 'shuffle': True, 'batch_size': 1}
             tr = DataLoader(dataset, **kwargs)
-        for i in tqdm(tr):
-            continue
+
+        tot = len(tr)
+        if args.num_batches != None:
+            stop = args.num_batches - 1
+            tot = args.num_batches
+        else:
+            stop = tot - 1
+        for idx, i in tqdm(enumerate(tr), total=tot):
+            if idx == stop:
+                break
 
         print("Attempting to read validation data")
         if args.lightning:
@@ -133,8 +148,17 @@ def dataset_stats(argv=None):
             dataset.set_subset(validate=True)
             kwargs.pop('shuffle')
             va = DataLoader(dataset, **kwargs)
-        for i in tqdm(va):
-            continue
+
+        tot = len(va)
+        if args.num_batches != None:
+            stop = args.num_batches - 1
+            tot = args.num_batches
+        else:
+            stop = tot - 1
+        for idx, i in tqdm(enumerate(va), total=tot):
+            if idx == stop:
+                break
+
         #print("Attempting to read testing data")
         #for i in tqdm(te):
         #    continue
@@ -240,6 +264,35 @@ class SeqCollater:
         idx_ret = torch.tensor(idx_ret)
         seq_id_ret = torch.tensor(seq_id_ret)
         return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret)
+
+class TrainingSeqCollater:
+
+    def __init__(self, padval):
+        self.padval = padval
+
+    def __call__(self, samples):
+        maxlen = 0
+        l_idx = -1
+        if isinstance(samples, tuple):
+            samples = [samples]
+        for i, X, y, seq_id in samples:
+            if maxlen < X.shape[l_idx]:
+                maxlen = X.shape[l_idx]
+        X_ret = list()
+        y_ret = list()
+        idx_ret = list()
+        for i, X, y, seq_id in samples:
+            dif = maxlen - X.shape[l_idx]
+            X_ = X
+            if dif > 0:
+                X_ = F.pad(X, (0, dif), value=self.padval)
+            X_ret.append(X_)
+            y_ret.append(y)
+            idx_ret.append(int(i))
+        X_ret = torch.stack(X_ret)
+        y_ret = torch.stack(y_ret)
+        idx_ret = torch.tensor(idx_ret)
+        return (X_ret, y_ret, idx_ret)
 
 
 def _check_collater(padval, seq_collater):
@@ -572,7 +625,7 @@ def train_test_loaders(dataset, random_state=None, downsample=None, **kwargs):
     return (tr_dl, va_dl, te_dl)
 
 
-def get_collater(dataset):
+def get_collater(dataset, inference=False):
     if dataset.tnf:
         return TnfCollater(dataset.vocab)
     elif dataset.manifold:
@@ -580,7 +633,10 @@ def get_collater(dataset):
     elif dataset.graph:
         return GraphCollater(dataset.node_ids, seq_collater=collater)
     else:
-        return SeqCollater(dataset.padval)
+        if inference:
+            return SeqCollater(dataset.padval)
+        else:
+            return TrainingSeqCollater(dataset.padval)
 
 
 def get_loader(dataset, distances=False, graph=False, **kwargs):
@@ -610,6 +666,39 @@ def get_loader(dataset, distances=False, graph=False, **kwargs):
     return DataLoader(orig_dataset, collate_fn=collater, **kwargs)
 
 
+class WORSampler(Sampler):
+    """Without Replacement Sampler"""
+
+    def __init__(self, length, rng=None):
+        super().__init__(None)
+        if rng is None:
+            rng = np.random.default_rng()
+        elif isinstance(rng, (int, np.integer)):
+            rng = np.random.default_rng(rng)
+        self.rng = rng
+        dtype = np.uint32
+        if length > (2**32 - 1):
+            dtype = np.uint64
+        self.indices = np.arange(length, dtype=dtype)
+        self.curr_len = length
+
+    def __iter__(self):
+        self.curr_len = len(self.indices)
+        return self
+
+    def __len__(self):
+        return len(self.indices)
+
+    def __next__(self):
+        if self.curr_len == 0:
+            raise StopIteration
+        idx = self.rng.integers(self.curr_len)
+        ret = self.indices[idx]
+        self.indices[self.curr_len - 1], self.indices[idx] = self.indices[idx], self.indices[self.curr_len - 1]
+        self.curr_len -= 1
+        return ret
+
+
 class DeepIndexDataModule(pl.LightningDataModule):
 
     def __init__(self, hparams, inference=False, keep_open=False):
@@ -626,7 +715,13 @@ class DeepIndexDataModule(pl.LightningDataModule):
             self.dataset = LazySeqDataset(hparams=hparams, keep_open=keep_open)
             self.dataset.load(sequence=hparams.load)
             kwargs['pin_memory'] = hparams.pin_memory
-            kwargs['shuffle'] = hparams.shuffle
+            #kwargs['shuffle'] = hparams.shuffle
+            kwargs['shuffle'] = False
+            if hparams.shuffle:
+                self.dataset.set_subset(train=True)
+                train_len = len(self.dataset)
+                self.dataset.set_subset()
+                kwargs['sampler'] = WORSampler(train_len)
 
         kwargs.update(hparams.loader_kwargs)
         kwargs['num_workers'] = hparams.num_workers
@@ -635,7 +730,7 @@ class DeepIndexDataModule(pl.LightningDataModule):
             kwargs['worker_init_fn'] = self.dataset.worker_init
             kwargs['persistent_workers'] = True
 
-        kwargs['collate_fn'] = get_collater(self.dataset)
+        kwargs['collate_fn'] = get_collater(self.dataset, inference=inference)
 
         self._loader_kwargs = kwargs
 
@@ -655,6 +750,7 @@ class DeepIndexDataModule(pl.LightningDataModule):
         self._check_close()
         kwargs = self._loader_kwargs.copy()
         kwargs.pop('shuffle', False)
+        kwargs.pop('sampler', False)
         return DataLoader(self.dataset, **kwargs)
 
     def test_dataloader(self):

--- a/src/exabiome/nn/models/lit.py
+++ b/src/exabiome/nn/models/lit.py
@@ -133,7 +133,7 @@ class AbstractLit(LightningModule):
 
     # TRAIN
     def training_step(self, batch, batch_idx):
-        idx, seqs, target, olen, seq_id = batch
+        seqs, target = batch
         output = self.forward(seqs)
         loss = self._loss(output, target)
         if self.hparams.classify:
@@ -147,7 +147,7 @@ class AbstractLit(LightningModule):
 
     # VALIDATION
     def validation_step(self, batch, batch_idx):
-        idx, seqs, target, olen, seq_id = batch
+        seqs, target = batch
         output = self(seqs)
         loss = self._loss(output, target)
         if self.hparams.classify:
@@ -161,7 +161,7 @@ class AbstractLit(LightningModule):
 
     # TEST
     def test_step(self, batch, batch_idx):
-        idx, seqs, target, olen, seq_id = batch
+        seqs, target = batch
         output = self(seqs)
         loss = self._loss(output, target)
         self.log(self.test_loss, loss)

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -4,6 +4,8 @@ import os.path
 import pickle
 import json
 import ruamel.yaml as yaml
+from time import time
+from tqdm import tqdm
 from datetime import datetime
 import numpy as np
 from ..utils import parse_seed, check_argv, parse_logger, check_directory
@@ -319,6 +321,87 @@ def process_args(args=None, return_io=False):
 
 
 
+def benchmark_pass(argv=None):
+    '''Read dataset and run an epoch'''
+    import numpy as np
+    import traceback
+    import os
+    import pprint
+    import torch.nn as nn
+    import torch
+
+
+    pformat = pprint.PrettyPrinter(sort_dicts=False, width=100, indent=2).pformat
+
+    desc = "Read dataset and run an epoch"
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('config', type=str, help='the config file for this training run')
+    parser.add_argument('input', type=str, help='the HDF5 DeepIndex file')
+    parser.add_argument('-N', '--num_batches', type=int, help='the number of batches to load when testing read', default=None)
+    parser.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=0)
+    parser.add_argument('-y', '--pin_memory', action='store_true', default=False, help='pin memory when loading data')
+    parser.add_argument('-f', '--shuffle', action='store_true', default=False, help='shuffle batches when training')
+    parser.add_argument('-b', '--batch_size', type=int, help='the number of workers to load data with', default=1)
+    parser.add_argument('-s', '--seed', type=parse_seed, default='', help='seed for an 80/10/10 split before reading an element')
+    parser.add_argument('-l', '--load', action='store_true', default=False, help='load data into memory before running training loop')
+
+    args = parser.parse_args(argv)
+    process_config(args.config, args)
+    if len(argv) == 0:
+        parser.print_help()
+        sys.exit(1)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    args.loader_kwargs = dict()
+
+    before = time()
+    data_mod = DeepIndexDataModule(args, keep_open=True)
+    after = time()
+
+    args.input_nc = 136 if args.tnf else len(data_mod.dataset.vocab)
+    if args.classify:
+        args.n_outputs = len(data_mod.dataset.taxa_labels)
+    model = process_model(args, taxa_table=data_mod.dataset.difile.taxa_table)
+
+    dataset = data_mod.dataset
+    print(f'Took {after - before} seconds to open {args.input}')
+    difile = dataset.difile
+
+    n_taxa = len(difile.taxa_table)
+    n_seqs = len(difile.seq_table)
+
+    n_samples = len(dataset)
+    n_disc = difile.n_discarded
+    wlen = args.window
+    step = args.step
+
+    if wlen is not None:
+        print((f'Splitting {n_seqs} sequences (from {n_taxa} species) into {wlen} '
+               f'bp windows every {step} bps produces {n_samples} samples '
+               f'(after discarding {n_disc} samples).'))
+    else:
+        print(f'Found {n_seqs} sequences across {n_taxa} species. {n_samples} total samples')
+
+
+    tr = data_mod.train_dataloader()
+    tot = len(tr)
+    if args.num_batches != None:
+        stop = args.num_batches - 1
+        tot = args.num_batches
+    else:
+        stop = tot - 1
+
+    model.to(device)
+    loss = nn.CrossEntropyLoss()
+    print(f'Running {tot} batches of size {args.batch_size} through model')
+    for idx, i in tqdm(enumerate(tr), total=tot):
+        result = model(i[0].to(device))
+        loss(result, i[1].to(device))
+        if idx == stop:
+            break
+
+
 def print0(*msg, **kwargs):
     if RANK == 0:
         print(*msg, **kwargs)
@@ -332,7 +415,7 @@ def run_lightning(argv=None):
     import os
     import pprint
 
-    pformat = pprint.PrettyPrinter(sort_dicts=False, width=100).pformat
+    pformat = pprint.PrettyPrinter(sort_dicts=False, width=100, indent=2).pformat
 
     model, args, addl_targs, data_mod = process_args(parse_args(argv=argv))
     # if 'OMPI_COMM_WORLD_RANK' in os.environ or 'SLURMD_NODENAME' in os.environ:
@@ -347,7 +430,7 @@ def run_lightning(argv=None):
     outdir, output = process_output(args)
     check_directory(outdir)
     print0(' '.join(sys.argv), file=sys.stderr)
-    print0("Processed Args:", pformat(vars(args)), file=sys.stderr)
+    print0("Processed Args:\n", pformat(vars(args)), file=sys.stderr)
 
     # save arguments
     with open(output('args.pkl'), 'wb') as f:
@@ -405,8 +488,8 @@ def run_lightning(argv=None):
         targs['log_every_n_steps'] = 1
         targs['fast_dev_run'] = 10
 
-    print0('Trainer args:', pformat(targs), file=sys.stderr)
-    print0('DataLoader args:', pformat(data_mod._loader_kwargs), file=sys.stderr)
+    print0('Trainer args:\n', pformat(targs), file=sys.stderr)
+    print0('DataLoader args:\n', pformat(data_mod._loader_kwargs), file=sys.stderr)
     print0('Model:\n', model, file=sys.stderr)
 
     trainer = Trainer(**targs)


### PR DESCRIPTION
Two things:

- Add a new command for loading data and running batches through a model. This is useful for quick benchmarking.
- Always use custom shuffling. Before, we relied on the shuffle argument in [PyTorch DataLoader](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader) to do this. Somehow, it was generating a very large memory footprint, which I believe and was slowing things down for larger datasets. I replaced this with `WORSampler` in `exabiome.nn.loader`. 
  - `-f`/`--shuffle` still exists, but does not do anything  