### PR TITLE
Add space-efficient sampler

### DIFF
--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -311,7 +311,6 @@ def process_args(args=None, return_io=False):
 
     if args.num_workers > 0:
         data_mod.dataset.close()
-        #pass
 
     ret = [model, args, targs]
     if return_io:
@@ -387,6 +386,8 @@ def benchmark_pass(argv=None):
 
 
     tr = data_mod.train_dataloader()
+    # Get validation dataloader to make sure that doesn't screw up the train dataloader
+    va = data_mod.val_dataloader()
     tot = len(tr)
     if args.num_batches != None:
         stop = args.num_batches - 1

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -722,13 +722,16 @@ class LazyWindowChunkedDIFile(DIFileFilter):
         if not isinstance(i, (int, np.integer)):
             raise ValueError("LazyWindowChunkedDIFile only supports indexing with an integer")
 
-        if i < 0:
-            i += self.lut[i]
-            if i < 0:
+        idx = i
+        if idx < 0:
+            idx += self.lut[-1]
+            if idx < 0:
                 raise IndexError(f'index {i} is out of bounds for LazyWindowChunkedDIFile of length {self.lut[-1]}')
 
-        seq_i = np.searchsorted(self.lut, i, side="right")
-        chunk_i = i if seq_i == 0 else i - self.lut[seq_i - 1]
+        seq_i = np.searchsorted(self.lut, idx, side="right")
+        if seq_i == len(self.lut):
+            raise IndexError(f'index {i} out of bounds for LazyWindowChunkedDIFile of length {self.lut[-1]}')
+        chunk_i = idx if seq_i == 0 else idx - self.lut[seq_i - 1]
 
         if self.subset_counts is not None:
             if self.starts is not None:


### PR DESCRIPTION
Two things:

- Add a new command for loading data and running batches through a model. This is useful for quick benchmarking.
- Always use custom shuffling. Before, we relied on the shuffle argument in [PyTorch DataLoader](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader) to do this. Somehow, it was generating a very large memory footprint, which I believe and was slowing things down for larger datasets. I replaced this with `WORSampler` in `exabiome.nn.loader`. 
  - `-f`/`--shuffle` still exists, but does not do anything  
  - This PR should actually ensure that the WORSampler works