### PR TITLE
Memory and I/O  efficient inference code

### DIFF
--- a/src/exabiome/__init__.py
+++ b/src/exabiome/__init__.py
@@ -50,6 +50,7 @@ def main():
         },
         'Inference and model assessment': {
             'infer': Command('nn.infer.run_inference', 'Run inference using PyTorch'),
+            'infer-job': Command('run.run_infer.run_inference', 'Run a training job'),
             'agg-chunks': Command('nn.summarize.aggregate_chunks', 'aggregate sequence chunks to get NN outputs for individual sequences'),
             'agg-seqs': Command('nn.summarize.aggregate_seqs', 'aggregate sequence chunks to get NN outputs for individual taxons (i.e. labels)'),
             'tax-acc': Command('nn.summarize.taxonomic_accuracy', 'calculate classificaiton accuracy across all possible taxonomic levels'),

--- a/src/exabiome/__init__.py
+++ b/src/exabiome/__init__.py
@@ -27,7 +27,7 @@ def main():
         },
         'Training and models': {
             'train': Command('nn.train.run_lightning', 'Run training with PyTorch Lightning'),
-            'train-job': Command('run.run_job.run_train', 'Run a training job'),
+            'train-job': Command('run.run_job.run_train', 'Run an inference job'),
             'train-conf': Command('nn.train.print_config_options', 'Print the available options for a config file'),
             'conf-tmpl': Command('nn.train.print_config_templ', 'Print an empty config file'),
             'show-args': Command('nn.train.print_args', 'display input arguments for training run'),

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -155,8 +155,8 @@ def parse_args(*addl_args, argv=None):
     prof_grp = parser.add_mutually_exclusive_group()
     prof_grp.add_argument('--profile', action='store_true', default=False, help='profile with PyTorch Lightning profile')
     prof_grp.add_argument('--cuda_profile', action='store_true', default=False, help='profile with PyTorch CUDA profiling')
-    parser.add_argument('--sanity', action='store_true', default=False,
-                        help='run five epochs with 40 batches for training and 5 batches for validation ')
+    parser.add_argument('-s', '--sanity', metavar='NBAT', nargs='?', const=True, default=False,
+                        help='run NBAT batches for training and NBAT//4 batches for validation. By default, NBAT=4000')
     parser.add_argument('--lr_find', default=False, action='store_true', help='find optimal learning rate')
     grp = parser.add_argument_group('Distributed training environments').add_mutually_exclusive_group()
     grp.add_argument('--horovod', default=False, action='store_true', help='run using Horovod backend')
@@ -255,8 +255,12 @@ def process_args(args=None, return_io=False):
         )
 
     if args.sanity:
-        targs['limit_train_batches'] = 4000
-        targs['limit_val_batches'] = 500
+        if isinstance(args.sanity, str):
+            args.sanity = int(args.sanity)
+        else:
+            args.sanity = 4000
+        targs['limit_train_batches'] = args.sanity
+        targs['limit_val_batches'] = args.sanity // 4
 
     if args.lr_find:
         targs['auto_lr_find'] = True

--- a/src/exabiome/run/nersc.py
+++ b/src/exabiome/run/nersc.py
@@ -11,7 +11,7 @@ class SlurmJob(AbstractJob):
     output_flag = 'o'
     error_flag = 'e'
     jobname_flag = 'J'
-    nodes_flag = 'n'
+    nodes_flag = '-ntasks'
     submit_cmd = 'sbatch'
     job_var = 'SLURM_JOB_ID'
     job_fmt_var = 'j'

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -87,7 +87,8 @@ def run_train(argv=None):
     parser.add_argument('-F', '--features',     help="a checkpoint file for features", default=None)
     parser.add_argument('-E', '--experiment',   help="the experiment name to use", default=None)
     parser.add_argument('-d', '--debug',        help="submit to debug queue", action='store_true', default=False)
-    parser.add_argument('--sanity',             help="run a small number of batches", action='store_true', default=False)
+    parser.add_argument('-s', '--sanity', metavar='NBAT', nargs='?', const=True, default=False,
+                        help='run NBAT batches for training and NBAT//4 batches for validation. By default, NBAT=4000')
     parser.add_argument('--early_stop',         help="use PL early stopping", action='store_true', default=False)
     parser.add_argument('--swa', action='store_true', default=False, help='use stochastic weight averaging')
     parser.add_argument('-l', '--load',         help="load dataset into memory", action='store_true', default=False)
@@ -133,6 +134,8 @@ def run_train(argv=None):
 
     if args.sanity:
         options = '--sanity'
+        if isinstance(args.sanity, str):
+            options += f' {args.sanity}'
 
     if args.early_stop:
         options += f' --early_stop'


### PR DESCRIPTION
The inference code for individual sequences required saving all the chunks for each sequence. Subsequently, `summary` code was run to aggregate the chunks for each sequence. This PR merges these two steps into one to avoid unnecessary I/O.

- `-s`/`--sanity` now takes an argument to specify the number of effective batches to run for a sanity run