### PR TITLE
Merge inference and summary, fix training samplers

### DIFF
--- a/src/exabiome/gtdb/prepare_data.py
+++ b/src/exabiome/gtdb/prepare_data.py
@@ -149,7 +149,6 @@ def prepare_data(argv=None):
     parser.add_argument('-z', '--gzip', action='store_true', default=False,
                         help='GZip sequence table')
     dep_grp = parser.add_argument_group(title="Legacy options you probably do not need")
-    dep_grp.add_argument('--non_vocab', action='store_false', dest='vocab', default=True, help='bitpack sequences -- it is unlikely this works')
     dep_grp.add_argument('-e', '--emb', type=str, help='embedding file', default=None)
 
     if len(sys.argv) == 1:
@@ -198,6 +197,8 @@ def prepare_data(argv=None):
     taxdf = taxdf[taxdf.index.str.contains('GC[A,F]_', regex=True)]   # get rid of genomes that are not at NCBI
     logger.info('Discarded %d non-NCBI genomes' % (dflen - len(taxdf)))
 
+    rep_taxdf = taxdf[taxdf.index == taxdf['gtdb_genome_representative']]
+
     if args.accessions is not None:
         logger.info('reading accessions %s' % args.accessions)
         with open(args.accessions, 'r') as f:
@@ -205,8 +206,6 @@ def prepare_data(argv=None):
         dflen = len(taxdf)
         taxdf = taxdf[taxdf.index.isin(accessions)]
         logger.info('Discarded %d genomes not found in %s' % (dflen - len(taxdf), args.accessions))
-
-    rep_taxdf = taxdf[taxdf.index == taxdf['gtdb_genome_representative']]
 
     dflen = len(taxdf)
     if args.nonrep:
@@ -290,102 +289,64 @@ def prepare_data(argv=None):
     logger.info("Total size: %d", sum(list(map_func(os.path.getsize,  fapaths))))
 
     tmp_h5_file = None
-    vocab = None
-    if args.iter:
-        if args.vocab:
-            if args.protein:
-                SeqTable = SequenceTable
-                seqit = AAVocabIterator(fapaths, logger=logger, min_seq_len=args.min_len)
-            else:
-                SeqTable = DNATable
-                seqit = DNAVocabIterator(fapaths, logger=logger, min_seq_len=args.min_len)
-            vocab = np.array(list(seqit.characters()))
-        else:
-            if args.protein:
-                logger.info("reading and writing protein sequences")
-                seqit = AASeqIterator(fapaths, logger=logger, max_degenerate=args.max_deg, min_seq_len=args.min_len)
-                SeqTable = AATable
-            else:
-                logger.info("reading and writing DNA sequences")
-                seqit = DNASeqIterator(fapaths, logger=logger, min_seq_len=args.min_len)
-                SeqTable = DNATable
-
-        seqit_bsize = 2**25
-        if args.protein:
-            seqit_bsize = 2**15
-        elif args.cds:
-            seqit_bsize = 2**18
-
-        # set up DataChunkIterators
-        sequence = DataChunkIterator.from_iterable(iter(seqit), maxshape=(None,), buffer_size=seqit_bsize, dtype=np.dtype('uint8'))
-        seqindex = DataChunkIterator.from_iterable(seqit.index_iter, maxshape=(None,), buffer_size=2**0, dtype=np.dtype('int'))
-        names = DataChunkIterator.from_iterable(seqit.names_iter, maxshape=(None,), buffer_size=2**0, dtype=np.dtype('U'))
-        ids = DataChunkIterator.from_iterable(seqit.id_iter, maxshape=(None,), buffer_size=2**0, dtype=np.dtype('int'))
-        taxa = DataChunkIterator.from_iterable(seqit.taxon_iter, maxshape=(None,), buffer_size=2**0, dtype=np.dtype('uint16'))
-        seqlens = DataChunkIterator.from_iterable(seqit.seqlens_iter, maxshape=(None,), buffer_size=2**0, dtype=np.dtype('uint32'))
+    if args.protein:
+        vocab_it = AAVocabIterator
+        SeqTable = SequenceTable
+        skbio_cls = Protein
     else:
-        if args.vocab:
-            if args.protein:
-                vocab_it = AAVocabIterator
-                SeqTable = SequenceTable
-                skbio_cls = Protein
-            else:
-                vocab_it = DNAVocabIterator
-                SeqTable = DNATable
-                skbio_cls = DNA
+        vocab_it = DNAVocabIterator
+        SeqTable = DNATable
+        skbio_cls = DNA
 
-            vocab = np.array(list(vocab_it.characters()))
-            if not args.protein:
-                np.testing.assert_array_equal(vocab, list('ACYWSKDVNTGRMHB'))
+    vocab = np.array(list(vocab_it.characters()))
+    if not args.protein:
+        np.testing.assert_array_equal(vocab, list('ACYWSKDVNTGRMHB'))
 
-            if args.total_seq_len is None:
-                logger.info('counting total number of sqeuences')
-                n_seqs, total_seq_len = np.array(list(zip(*tqdm(map_func(seqlen, fapaths), total=len(fapaths))))).sum(axis=1)
-                logger.info(f'found {total_seq_len} bases across {n_seqs} sequences')
-            else:
-                n_seqs, total_seq_len = args.n_seqs, args.total_seq_len
-                logger.info(f'As specified, there are {total_seq_len} bases across {n_seqs} sequences')
+    if args.total_seq_len is None:
+        logger.info('counting total number of sqeuences')
+        n_seqs, total_seq_len = np.array(list(zip(*tqdm(map_func(seqlen, fapaths), total=len(fapaths))))).sum(axis=1)
+        logger.info(f'found {total_seq_len} bases across {n_seqs} sequences')
+    else:
+        n_seqs, total_seq_len = args.n_seqs, args.total_seq_len
+        logger.info(f'As specified, there are {total_seq_len} bases across {n_seqs} sequences')
 
-            logger.info(f'allocating uint8 array of length {total_seq_len} for sequences')
+    logger.info(f'allocating uint8 array of length {total_seq_len} for sequences')
 
-            if args.tmpdir is not None:
-                if not os.path.exists(args.tmpdir):
-                    os.mkdir(args.tmpdir)
-                tmpdir = tempfile.mkdtemp(dir=args.tmpdir)
-            else:
-                tmpdir = tempfile.mkdtemp()
+    if args.tmpdir is not None:
+        if not os.path.exists(args.tmpdir):
+            os.mkdir(args.tmpdir)
+        tmpdir = tempfile.mkdtemp(dir=args.tmpdir)
+    else:
+        tmpdir = tempfile.mkdtemp()
 
-            comp = 'gzip' if args.gzip else None
-            tmp_h5_file = h5py.File(os.path.join(tmpdir, 'sequences.h5'), 'w')
-            sequence = tmp_h5_file.create_dataset('sequences', shape=(total_seq_len,), dtype=np.uint8, compression=comp)
-            seqindex = tmp_h5_file.create_dataset('sequences_index', shape=(n_seqs,), dtype=np.uint64, compression=comp)
-            genomes = tmp_h5_file.create_dataset('genomes', shape=(n_seqs,), dtype=np.uint64, compression=comp)
-            seqlens = tmp_h5_file.create_dataset('seqlens', shape=(n_seqs,), dtype=np.uint64, compression=comp)
-            names = tmp_h5_file.create_dataset('seqnames', shape=(n_seqs,), dtype=h5py.special_dtype(vlen=str), compression=comp)
+    comp = 'gzip' if args.gzip else None
+    tmp_h5_file = h5py.File(os.path.join(tmpdir, 'sequences.h5'), 'w')
+    sequence = tmp_h5_file.create_dataset('sequences', shape=(total_seq_len,), dtype=np.uint8, compression=comp)
+    seqindex = tmp_h5_file.create_dataset('sequences_index', shape=(n_seqs,), dtype=np.uint64, compression=comp)
+    genomes = tmp_h5_file.create_dataset('genomes', shape=(n_seqs,), dtype=np.uint64, compression=comp)
+    seqlens = tmp_h5_file.create_dataset('seqlens', shape=(n_seqs,), dtype=np.uint64, compression=comp)
+    names = tmp_h5_file.create_dataset('seqnames', shape=(n_seqs,), dtype=h5py.special_dtype(vlen=str), compression=comp)
 
-            taxa = np.zeros(len(fapaths), dtype=int)
+    taxa = np.zeros(len(fapaths), dtype=int)
 
-            seq_i = 0
-            b = 0
-            for genome_i, fa in tqdm(enumerate(fapaths), total=len(fapaths)):
-                kwargs = {'format': 'fasta', 'constructor': skbio_cls, 'validate': False}
-                taxid = taxa_ids[genome_i]
-                rep_taxid = taxdf['gtdb_genome_representative'][genome_i]
-                taxa[genome_i] = np.where(rep_taxdf.index == rep_taxid)[0][0]
-                for seq in skbio.io.read(fa, **kwargs):
-                    enc_seq = vocab_it.encode(seq)
-                    e = b + len(enc_seq)
-                    sequence[b:e] = enc_seq
-                    seqindex[seq_i] = e
-                    genomes[seq_i] = genome_i
-                    seqlens[seq_i] = len(enc_seq)
-                    names[seq_i] = vocab_it.get_seqname(seq)
-                    b = e
-                    seq_i += 1
-            ids = tmp_h5_file.create_dataset('ids', data=np.arange(n_seqs), dtype=int)
-
-        else:
-            raise NotImplementedError('cannot load all data into memory unless using vocab encoding')
+    seq_i = 0
+    b = 0
+    for genome_i, fa in tqdm(enumerate(fapaths), total=len(fapaths)):
+        kwargs = {'format': 'fasta', 'constructor': skbio_cls, 'validate': False}
+        taxid = taxa_ids[genome_i]
+        rep_taxid = taxdf['gtdb_genome_representative'][genome_i]
+        taxa[genome_i] = np.where(rep_taxdf.index == rep_taxid)[0][0]
+        for seq in skbio.io.read(fa, **kwargs):
+            enc_seq = vocab_it.encode(seq)
+            e = b + len(enc_seq)
+            sequence[b:e] = enc_seq
+            seqindex[seq_i] = e
+            genomes[seq_i] = genome_i
+            seqlens[seq_i] = len(enc_seq)
+            names[seq_i] = vocab_it.get_seqname(seq)
+            b = e
+            seq_i += 1
+    ids = tmp_h5_file.create_dataset('ids', data=np.arange(n_seqs), dtype=int)
 
     io = get_hdf5io(h5path, 'w')
 

--- a/src/exabiome/nn/__init__.py
+++ b/src/exabiome/nn/__init__.py
@@ -1,1 +1,1 @@
-from .loader import get_loader, train_test_loaders
+from .loader import get_loader

--- a/src/exabiome/nn/infer.py
+++ b/src/exabiome/nn/infer.py
@@ -345,8 +345,8 @@ def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
         # Add the first sum of this iteration to the last sum of the
         # previous iteration if they belong to the same sequence
         if len(seqs_q) > 0 and seqs_q[-1] == seqs[0]:
-            outputs_q[-1] += output_sum[0]
-            n_samples_q[-1] += counts[0]
+            outputs_q[-1] += outputs_sum[0]
+            counts_q[-1] += counts[0]
             # drop the first sum so we don't end up with duplicates
             seqs = seqs[1:]
             counts = counts[1:]
@@ -359,20 +359,20 @@ def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
         labels_q.extend(counts)
 
         if len(outputs_q) > args.n_seqs:
+            idx = seqs_q[:-1]
             # compute mean from sums
             for i in range(len(seqs_q) - 1):
                 outputs_q[i] /= counts_q[i]
 
-            idx = seqs_q[:-1]
             outputs_dset[idx] = outputs_q[:-1]
             labels_dset[idx] = labels_q[:-1]
 
-            if maxprobs_dset is not None:
+            if maxprob_dset is not None:
                 k = outputs_q[0].shape[0] - args.maxprob
                 maxprobs = list()
                 for i in range(len(idx)):
                     maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
-                maxprobs_dset[idx] = maxprobs
+                maxprob_dset[idx] = maxprobs
 
             if preds_dset is not None:
                 preds = [np.argmax(outputs_q[i]) for i in range(len(idx))]
@@ -390,12 +390,12 @@ def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
     outputs_dset[seqs_q] = outputs_q
     labels_dset[seqs_q] = labels_q
 
-    if maxprobs_dset is not None:
+    if maxprob_dset is not None:
         k = outputs_q[0].shape[0] - args.maxprob
         maxprobs = list()
         for i in range(len(seqs_q)):
             maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
-        maxprobs_dset[seqs_q] = maxprobs
+        maxprob_dset[seqs_q] = maxprobs
 
     if preds_dset is not None:
         preds = [np.argmax(outputs_q[i]) for i in range(len(seqs_q))]

--- a/src/exabiome/nn/infer.py
+++ b/src/exabiome/nn/infer.py
@@ -1,6 +1,7 @@
 import sys
 import numpy as np
 import os
+from time import time
 from functools import partial
 from ..utils import check_argv, parse_logger, ccm, distsplit
 from .utils import process_gpus, process_model, process_output
@@ -45,8 +46,13 @@ def parse_args(*addl_args, argv=None):
     parser.add_argument('-N', '--nonrep', action='append_const', const='nonrep', dest='loaders', help='the dataset is nonrepresentative species')
     parser.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=1)
     parser.add_argument('-M', '--in_memory', default=False, action='store_true', help='collect all batches in memory before writing to disk')
-    parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk')
+    parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk or aggregation')
     parser.add_argument('-s', '--start', type=int, help='sample index to start at', default=0)
+    parser.add_argument('-a', '--aggregate', action='store_true', help='aggregate chunks within sequences', default=False)
+    parser.add_argument('-S', '--n_seqs', type=int, default=2500, help='the number of sequences to aggregate chunks for between each write to disk')
+    parser.add_argument('-p', '--maxprob', metavar='TOPN', nargs='?', const=1, default=0, type=int,
+                        help='store the top TOPN probablities of each output. By default, TOPN=1')
+
     env_grp = parser.add_argument_group("Resource Manager").add_mutually_exclusive_group()
     env_grp.add_argument("--lsf", default=False, action='store_true', help='running in an LSF environment')
     env_grp.add_argument("--slurm", default=False, action='store_true', help='running in a SLURM environment')
@@ -138,44 +144,32 @@ def process_args(args, size=1, rank=0, comm=None):
         model = ResNetFeatures(model)
         args.features = True
 
-    if args.loaders is None or len(args.loaders) == 0:
-        args.loaders = ['train', 'validate']
-
-    close_file = False
-    if 'nonrep' in args.loaders:
-        if size > 1:
-            dataset = LazySeqDataset(path=args.input, hparams=argparse.Namespace(**model.hparams), keep_open=True, comm=comm, size=size, rank=rank)
-            args.logger.info(f'rank {rank} - processing {len(dataset)} samples subset')
-        else:
-            dataset = LazySeqDataset(path=args.input, hparams=argparse.Namespace(**model.hparams), keep_open=True)
-        tmp_dset = dataset
-        if args.start > 0:
-            warnings.warn('Ignoring --start. Updated code does not support this')
-
-        kwargs = dict(batch_size=args.batch_size, shuffle=False)
-        if args.num_workers > 0:
-            kwargs['num_workers'] = args.num_workers
-            kwargs['multiprocessing_context'] = 'spawn'
-            kwargs['worker_init_fn'] = dataset.worker_init
-            kwargs['persistent_workers'] = True
-            dataset.close()
-        ldr = get_loader(tmp_dset, inference=True, **kwargs)
-
-        args.loaders = {'nonrep': ldr}
-        args.difile = dataset.difile
+    if size > 1:
+        dataset = LazySeqDataset(path=args.input, hparams=argparse.Namespace(**model.hparams), keep_open=True, comm=comm, size=size, rank=rank)
+        args.logger.info(f'rank {rank} - processing {len(dataset)} samples subset')
     else:
-        args.loader_kwargs = {'rank': rank, 'size': size}
-        data_mod = DeepIndexDataModule(args, inference=True, keep_open=True)
-        args.loaders = {'train': data_mod.train_dataloader(),
-                        'validate': data_mod.val_dataloader()}
-        args.difile = data_mod.dataset.difile
-        if args.num_workers > 0:
-            data_mod.dataset.close()
-        dataset = data_mod.dataset
+        dataset = LazySeqDataset(path=args.input, hparams=argparse.Namespace(**model.hparams), keep_open=True)
+    tmp_dset = dataset
+    if args.start > 0:
+        warnings.warn('Ignoring --start. Updated code does not support this')
+
+    kwargs = dict(batch_size=args.batch_size, shuffle=False)
+    if args.num_workers > 0:
+        kwargs['num_workers'] = args.num_workers
+        kwargs['multiprocessing_context'] = 'spawn'
+        kwargs['worker_init_fn'] = dataset.worker_init
+        kwargs['persistent_workers'] = True
+    ldr = get_loader(tmp_dset, inference=True, **kwargs)
+
+    args.loader = ldr
+    args.difile = dataset.difile
 
     # return the model, any arguments, and Lighting Trainer args just in case
     # we want to use them down the line when we figure out how to use Lightning for
     # inference
+
+    if not args.features:
+        model = nn.Sequential(model, nn.Softmax(dim=1))
 
     model.eval()
 
@@ -231,10 +225,15 @@ def run_inference(argv=None):
         in_memory_inference(model, dataset, args, addl_targs)
     else:
         if SIZE > 1:
+            fkwargs['comm'] = COMM
             args.logger.info(f'running parallel chunked inference')
         else:
             args.logger.info(f'running serial chunked inference')
-        parallel_chunked_inference(model, dataset, args, addl_targs, COMM, SIZE, RANK, f_kwargs, probs=not args.features)
+        if args.aggregate:
+            parallel_chunked_inf_summ(model, dataset, args, addl_targs, f_kwargs)
+        else:
+            args.logger.info('not doing antying -- you kept around old, dead code that you should probably remove')
+            #parallel_chunked_inference(model, dataset, args, addl_targs, COMM, SIZE, RANK, f_kwargs, probs=not args.features)
 
 
 def parallel_chunked_inference(model, dataset, args, addl_targs, comm, size, rank, fkwargs, probs=True):
@@ -298,6 +297,115 @@ def parallel_chunked_inference(model, dataset, args, addl_targs, comm, size, ran
 
     f.close()
     if rank == 0: args.logger.info(f'closing {args.output}')
+
+
+def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
+
+    n_samples = len(dataset.orig_difile.seq_table)
+    all_seq_ids = dataset.orig_difile.get_sequence_subset()
+    seq_lengths  = dataset.orig_difile.get_seq_lengths()
+
+    f = h5py.File(args.output, 'w', **fkwargs)
+    outputs_dset = f.require_dataset('outputs', shape=(n_samples, args.n_outputs), dtype=float)
+    labels_dset = f.require_dataset('labels', shape=(n_samples,), dtype=int)
+
+    maxprob_dset = None
+    if args.maxprob > 0 :
+        maxprob_dset = f.require_dataset('maxprob', shape=(n_samples, args.maxprob), dtype=int)
+
+    preds_dset = f.require_dataset('preds', shape=(n_samples,), dtype=int)
+    seqlen_dset = f.require_dataset('lengths', shape=(n_samples,), dtype=int)
+
+    # to-write queues - we use those so we're not doing I/O at every iteration
+    outputs_q = list()
+    labels_q = list()
+    counts_q = list()
+    seqs_q = list()
+
+    # write what's in the to-write queues
+    if not hasattr(args, 'n_seqs'):
+        args.n_seqs = 2500
+
+    # ensure that dataset is closed before we start up the DataLoader
+    dataset.close()
+
+    # send model to GPU
+    model.to(args.device)
+
+    for idx, _outputs, _labels, _orig_lens, _seq_ids in get_outputs(model, args.loader, args.device, debug=args.debug, chunks=args.n_batches, prog_bar=dataset.rank==0):
+
+        seqs, counts = np.unique(_seq_ids, return_counts=True)
+        outputs_sum = list()
+        labels = list()
+        for i in seqs:
+            mask = _seq_ids == i
+            outputs_sum.append(_outputs[mask].sum(axis=0))
+            labels.append(_labels[mask][0])
+
+        # Add the first sum of this iteration to the last sum of the
+        # previous iteration if they belong to the same sequence
+        if len(seqs_q) > 0 and seqs_q[-1] == seqs[0]:
+            outputs_q[-1] += output_sum[0]
+            n_samples_q[-1] += counts[0]
+            # drop the first sum so we don't end up with duplicates
+            seqs = seqs[1:]
+            counts = counts[1:]
+            outputs_sum = outputs_sum[1:]
+            labels = labels[1:]
+
+        outputs_q.extend(outputs_sum)
+        seqs_q.extend(seqs)
+        counts_q.extend(counts)
+        labels_q.extend(counts)
+
+        if len(outputs_q) > args.n_seqs:
+            # compute mean from sums
+            for i in range(len(seqs_q) - 1):
+                outputs_q[i] /= counts_q[i]
+
+            idx = seqs_q[:-1]
+            outputs_dset[idx] = outputs_q[:-1]
+            labels_dset[idx] = labels_q[:-1]
+
+            if maxprobs_dset is not None:
+                k = outputs_q[0].shape[0] - args.maxprob
+                maxprobs = list()
+                for i in range(len(idx)):
+                    maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
+                maxprobs_dset[idx] = maxprobs
+
+            if preds_dset is not None:
+                preds = [np.argmax(outputs_q[i]) for i in range(len(idx))]
+                preds_dset[idx] = preds
+
+            outputs_q = outputs_q[-1:]
+            seqs_q = seqs_q[-1:]
+            counts_q = counts_q[-1:]
+            labels_q = labels_q[-1:]
+
+    # clean up what's left in the to-write queue
+    for i in range(seqs_q):
+        outputs_q[i] /= counts_q[i]
+
+    outputs_dset[seqs_q] = outputs_q
+    labels_dset[seqs_q] = labels_q
+
+    if maxprobs_dset is not None:
+        k = outputs_q[0].shape[0] - args.maxprob
+        maxprobs = list()
+        for i in range(len(seqs_q)):
+            maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
+        maxprobs_dset[seqs_q] = maxprobs
+
+    if preds_dset is not None:
+        preds = [np.argmax(outputs_q[i]) for i in range(len(seqs_q))]
+        preds_dset[seqs_q] = preds
+
+
+    # copy sequences lengths for convenience
+    if dataset.rank == 0: args.logger.info(f'closing {args.output}')
+
+    f.close()
 
 
 def get_outputs(model, loader, device, debug=False, chunks=None, prog_bar=True):

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -1034,6 +1034,10 @@ class LazySeqDataset(Dataset):
 
         self._set_subset(train=self._train_subset, validate=self._validate_subset, test=self._test_subset)
 
+    @property
+    def rank(self):
+        return self._global_rank
+
     def worker_init(self, worker_id):
         # September 15, 2021, ajtritt
         # This print statement is necessary to avoid processings from hanging when they are started

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -121,7 +121,7 @@ def dataset_stats(argv=None):
     while not isinstance(orig_difile, DeepIndexFile):
         orig_difile = orig_difile.difile
 
-    n_taxa = len(orig_difile.taxa_table)
+    n_taxa = len(orig_difile.genome_table)
     n_seqs = len(orig_difile.seq_table)
 
     n_samples = len(dataset)
@@ -476,176 +476,6 @@ class TnfCollater:
         return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret)
 
 
-import torch.distributed as dist
-
-def train_test_validate_split(indices, stratify=None, random_state=None,
-                              test_size=None, train_size=None, validation_size=None):
-    """
-    Return train test validation split for the given indices
-    Args:
-        indices   : indices for the dataset
-        kwargs    : any additional arguments to pass into torch.DataLoader
-    """
-
-    random_state = check_random_state(random_state)
-
-    before = time()
-    print("Splitting out training data", file=sys.stderr)
-    train_idx, tmp_idx = train_test_split(indices,
-                                          train_size=train_size,
-                                          stratify=stratify,
-                                          random_state=random_state)
-    after = time()
-    print(f'Took {after - before} seconds to split out training data', file=sys.stderr)
-
-    if stratify is not None:
-        stratify = stratify[tmp_idx]
-
-    before = time()
-    print("Splitting validation and test data", file=sys.stderr)
-    test_idx, val_idx = train_test_split(tmp_idx,
-                                         train_size=test_size,
-                                         stratify=stratify,
-                                         random_state=random_state)
-    after = time()
-    print(f'Took {after - before} seconds to split validation and test data', file=sys.stderr)
-
-    train_idx = indices[train_idx]
-    test_idx = indices[test_idx]
-    val_idx = indices[val_idx]
-
-    return train_idx, test_idx, val_idx
-
-
-class DatasetSubset(Dataset):
-
-    def __init__(self, dataset, index):
-        self.index = index
-        self.dataset = dataset
-
-    def __getitem__(self, i):
-        return self.dataset[self.index[i]]
-
-    def __len__(self):
-        return len(self.index)
-
-    # def __getattr__(self, attr):
-    #     return getattr(self.dataset, attr)
-
-
-def train_test_loaders(dataset, random_state=None, downsample=None, **kwargs):
-    """
-    Return DataLoaders for training, validation, and test datasets.
-
-    Parameters
-    ----------
-    dataset: LazySeqDataset
-        the path to the DeepIndex file
-
-    random_state: int or RandomState, default=None
-        The seed to use for randomly splitting data
-
-    downsample: float, default=None
-        Fraction to downsample data to before setting up DataLoaders
-
-    kwargs:
-        any additional arguments to pass into torch.DataLoader. Note
-        *shuffle* will be ignored for when creating validation and test
-        loaders i.e. no shuffling for validation and testing
-    """
-    random_state = check_random_state(random_state)
-    n_samples = len(dataset)
-    test_size = int(n_samples/10)
-    validation_size = test_size
-    train_size = n_samples - 2 * test_size
-
-    print(f'Permuting {len(dataset)} integers', file=sys.stderr)
-    before = time()
-    indices = random_state.permutation(np.arange(len(dataset), dtype=np.uint32))
-    after = time()
-    print(f'Took {after - before} to permute indices', file=sys.stderr)
-
-    train_idx = indices[:train_size]
-    validate_idx = indices[train_size:train_size + validation_size]
-    test_idx = indices[train_size + validation_size:]
-
-    #rank = dist.get_rank()
-
-    # from mpi4py import MPI
-    # comm =  MPI.COMM_WORLD
-    # rank = comm.Get_rank()
-    # print(f'My rank is {rank}', file=sys.stderr)
-
-    # if rank == 0:
-    #     dataset.open()  # open the dataset so we can get labels for each sample
-    #     before = time()
-    #     stratify = dataset.sample_labels
-    #     after = time()
-    #     print(f'Took {after - before} seconds to get sample labels for stratifying splits', file=sys.stderr)
-
-    #     before = time()
-    #     train_idx, test_idx, validate_idx = train_test_validate_split(np.arange(len(dataset)),
-    #                                                                   stratify=stratify,
-    #                                                                   random_state=random_state,
-    #                                                                   train_size=train_size,
-    #                                                                   validation_size=validation_size,
-    #                                                                   test_size=test_size,)
-    #     after = time()
-    #     print(f'Took {after - before} seconds to compute splits', file=sys.stderr)
-    #     dataset.close()   # now close it so dataset can be pickled when passing it to DataLoader workers
-    # else:
-    #     train_idx = np.zeros(train_size)
-    #     validate_idx = np.zeros(validation_size)
-    #     test_idx = np.zeros(test_size)
-
-    # if rank == 0:
-    #     print(f'Attempting to broadcast train_idx', file=sys.stderr)
-    # comm.Bcast(train_idx, root=0)
-    # if rank == 0:
-    #     print(f'Attempting to broadcast validate_idx', file=sys.stderr)
-    # comm.Bcast(validate_idx, root=0)
-    # if rank == 0:
-    #     print(f'Attempting to broadcast test_idx', file=sys.stderr)
-    # comm.Bcast(test_idx, root=0)
-
-    if dataset.tnf:
-        collater = TnfCollater(dataset.vocab)
-    elif dataset.manifold:
-        collater = DistanceCollater(dataset.distances, seq_collater=collater)
-    elif dataset.graph:
-        collater = GraphCollater(dataset.node_ids, seq_collater=collater)
-    else:
-        collater = SeqCollater(dataset.padval)
-
-
-    if kwargs.get('num_workers', None) not in (None, 0):
-        if dataset.difile is not None:
-            msg = (f'Requesting {kwargs["num_workers"]} workers for loading data -- '
-                   'closing dataset to avoid pickling error. '
-                   'To suppress this warning, Set keep_open=False when constructing LazySeqDataset '
-                   'or call dataset.close before passing to train_test_loaders')
-            warnings.warn(msg)
-            dataset.close()
-
-    train_dataset = DatasetSubset(dataset, train_idx)
-    test_dataset = DatasetSubset(dataset, test_idx)
-    validate_dataset = DatasetSubset(dataset, validate_idx)
-
-    s = kwargs.pop('size', 1)
-    r = kwargs.pop('rank', -1)
-    if s > 1 and r >= 0:
-        train_dataset = Subset(train_dataset, distsplit(len(train_dataset), s, r))
-        test_dataset = Subset(test_dataset, distsplit(len(test_dataset), s, r))
-        validate_dataset = Subset(validate_dataset, distsplit(len(validate_dataset), s, r))
-
-    tr_dl = DataLoader(train_dataset, collate_fn=collater, **kwargs)
-    kwargs.pop('shuffle', None)
-    va_dl = DataLoader(test_dataset, collate_fn=collater, **kwargs)
-    te_dl = DataLoader(validate_dataset, collate_fn=collater, **kwargs)
-
-    return (tr_dl, va_dl, te_dl)
-
-
 def get_collater(dataset, inference=False):
     if dataset.tnf:
         return TnfCollater(dataset.vocab)
@@ -729,14 +559,36 @@ class WORSampler(Sampler):
         return ret
 
 
+class DSSampler(Sampler):
+    """Distributed Sequential Sampler"""
+
+    def __init__(self, length, rank=0, size=1):
+        super().__init__(None)
+        if size > 1:
+            self.start, self.end = distsplit(length, size, rank, arange=False)
+        else:
+            self.start = 0
+            self.end = length
+
+    def __iter__(self):
+        return range(self.start, self.end)
+
+    def __len__(self):
+        return self.end - self.start
+
+
 class SubsetDataLoader(DataLoader):
 
     def __init__(self, dataset, train=False, validate=False, test=False, **kwargs):
+        if 'sampler' not in kwargs:
+            kwargs['sampler'] = DSSampler(dataset.get_subset_len(train=train, vaidate=validate, test=test))
         super().__init__(dataset, **kwargs)
         self.train = train
         self.validate = validate
         self.test = test
 
+    def __len__(self):
+        return (len(self.sampler) - 1) // self.batch_size + 1
 
     def __iter__(self):
         self.dataset.set_subset(train=self.train, validate=self.validate, test=self.test)
@@ -758,11 +610,14 @@ class DeepIndexDataModule(pl.LightningDataModule):
             self.dataset = LazySeqDataset(hparams=hparams, keep_open=keep_open)
             self.dataset.load(sequence=hparams.load)
             kwargs['pin_memory'] = hparams.pin_memory
-            kwargs['sampler'] = None
-            self.dataset.set_subset(train=True)
-            train_len = len(self.dataset)
-            self.dataset.set_subset()
-            kwargs['sampler'] = WORSampler(train_len, rng=seed, rank=rank, size=size)
+
+            # set up the training sampler - shuffle for training
+            train_len = self.dataset.get_subset_len(train=True)
+            self._tr_sampler = WORSampler(train_len, rng=seed, rank=rank, size=size)
+
+            # set up the validation sampler - DO NOT shuffle for training
+            val_len = self.dataset.get_subset_len(validate=True)
+            self._val_sampler = DSSampler(val_len, rank=rank, size=size)
 
         self._parallel_load = hparams.num_workers != None and hparams.num_workers > 0
 
@@ -786,13 +641,15 @@ class DeepIndexDataModule(pl.LightningDataModule):
         kwargs = self._loader_kwargs.copy()
         if self._parallel_load:
             self.dataset.close()
+        kwargs['sampler'] = self._tr_sampler
         return SubsetDataLoader(self.dataset, train=True, **kwargs)
 
     def val_dataloader(self):
         kwargs = self._loader_kwargs.copy()
         if self._parallel_load:
             self.dataset.close()
-        kwargs.pop('sampler', None)
+        #kwargs.pop('sampler', None)
+        kwargs['sampler'] = self._val_sampler
         return SubsetDataLoader(self.dataset, validate=True, **kwargs)
 
     def test_dataloader(self):
@@ -907,9 +764,6 @@ class LazySeqDataset(Dataset):
         self.hparams = hparams
         self.load_data = hparams.load
 
-        # memoize any chunking we've done so we only need to do it once
-        self._chunkings = dict()
-
         self.window, self.step = check_window(hparams.window, hparams.step)
         self.revcomp = not hparams.fwd_only
 
@@ -922,18 +776,23 @@ class LazySeqDataset(Dataset):
         self._validate_subset = False
         self._test_subset = False
 
+        self._val_counts = None
+        self._train_counts = None
+
         # open to get dataset length
         self.open()
         self.__len = len(self.difile)
+        self._orig_len = self.__len
         if self.__lazy_chunk:
             if isinstance(self.difile, DIFileFilter):
-                counts = self.difile.lut.copy()
+                counts = self.difile.get_counts(orig=True)
+                self._val_counts = np.round(self.val_frac * counts).astype(int)
+                self._train_counts = counts - self._val_counts
                 counts[1:] = counts[1:] - counts[:-1]
                 self.taxa_counts = np.bincount(self.orig_difile.labels, weights=counts).astype(int)
-                self.taxa_labels = np.arange(len(self.taxa_counts))
             else:
                 self.taxa_counts = np.bincount(self.orig_difile.labels).astype(int)
-                self.taxa_labels = np.arange(len(self.taxa_counts))
+            self.taxa_labels = np.arange(len(self.taxa_counts))
         else:
             self.taxa_labels, self.taxa_counts = np.unique(self.difile.labels, return_counts=True)
         self.label_names = self.difile.get_label_classes()
@@ -1051,13 +910,20 @@ class LazySeqDataset(Dataset):
         if self.__lazy_chunk:
             self.difile = LazyWindowChunkedDIFile(self.difile, window, step)
         else:
-            chunks = self._chunkings.get((window, step))
-            if chunks is None:
-                self._chunkings[(window, step)] = chunk_sequence(self.difile, window, step)
-            self.difile = AbstractChunkedDIFile(self.difile, *self._chunkings[(window, step)])
+            raise ValueError("We only support lazy chunking now")
 
     def set_revcomp(self, revcomp=True):
         self.difile = RevCompFilter(self.difile)
+
+    def get_subset_len(self, train=False, validate=False, test=False):
+        rc = 2 if self.revcomp else 1
+        if train:
+            return self._train_counts.sum() * rc
+        elif validate:
+            return self._val_counts.sum() * rc
+        elif test:
+            raise ValueError("We don't support a test subset")
+        return self._orig_len
 
     def set_subset(self, train=False, validate=False, test=False):
         self._train_subset = train
@@ -1070,15 +936,12 @@ class LazySeqDataset(Dataset):
         if all((not train, not validate, not test)):
             self.difile.set_subset(None, None)
         else:
-            counts = self.difile.get_counts(orig=True)
-            val_counts = np.round(self.val_frac * counts).astype(int)
-            train_counts = counts - val_counts
             if validate:
-                self.difile.set_subset(val_counts, self.hparams.seed, starts=train_counts)
+                self.difile.set_subset(self._val_counts, self.hparams.seed, starts=self._train_counts)
             elif test:
                 raise ValueError("Cannot do this yet, and I may never do it, since we use held-out genomes for testing")
             else:
-                self.difile.set_subset(train_counts, self.hparams.seed)
+                self.difile.set_subset(self._train_counts, self.hparams.seed)
         self.__len = len(self.difile)
 
     def set_ohe(self, ohe=True):

--- a/src/exabiome/nn/models/lit.py
+++ b/src/exabiome/nn/models/lit.py
@@ -1,4 +1,3 @@
-from .. import train_test_loaders
 from pytorch_lightning import LightningModule
 import torch_optimizer as ptoptim
 import torch.optim as optim
@@ -63,16 +62,6 @@ class AbstractLit(LightningModule):
 
     def set_inference(self, inference=True):
         self._inference = inference
-
-    def set_dataset(self, dataset, load=True, inference=False):
-        kwargs = dict(random_state=self.hparams.seed,
-                      batch_size=self.hparams.batch_size,
-                      distances=self.hparams.manifold)
-
-        if inference:
-            kwargs['distances'] = False
-        tr, te, va = train_test_loaders(dataset, **kwargs)
-        self.loaders = {'train': tr, 'test': te, 'validate': va}
 
     def configure_optimizers(self):
         optimizer = None

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -167,6 +167,7 @@ def parse_args(*addl_args, argv=None):
     dl_grp.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=0)
     dl_grp.add_argument('-y', '--pin_memory', action='store_true', default=False, help='pin memory when loading data')
     dl_grp.add_argument('-f', '--shuffle', action='store_true', default=False, help='shuffle batches when training')
+    parser.add_argument('-q', '--quiet', action='store_true', default=False, help='do not print arguments, model, etc.')
 
     for a in addl_args:
         parser.add_argument(*a[0], **a[1])
@@ -436,8 +437,9 @@ def run_lightning(argv=None):
     # output is a wrapper function for os.path.join(outdir, <FILE>)
     outdir, output = process_output(args)
     check_directory(outdir)
-    print0(' '.join(sys.argv), file=sys.stderr)
-    print0("Processed Args:\n", pformat(vars(args)), file=sys.stderr)
+    if not args.quiet:
+        print0(' '.join(sys.argv), file=sys.stderr)
+        print0("Processed Args:\n", pformat(vars(args)), file=sys.stderr)
 
     # save arguments
     with open(output('args.pkl'), 'wb') as f:
@@ -495,9 +497,10 @@ def run_lightning(argv=None):
         targs['log_every_n_steps'] = 1
         targs['fast_dev_run'] = 10
 
-    print0('Trainer args:\n', pformat(targs), file=sys.stderr)
-    print0('DataLoader args\n:', pformat(data_mod._loader_kwargs), file=sys.stderr)
-    print0('Model:\n', model, file=sys.stderr)
+    if not args.quiet:
+        print0('Trainer args:\n', pformat(targs), file=sys.stderr)
+        print0('DataLoader args\n:', pformat(data_mod._loader_kwargs), file=sys.stderr)
+        print0('Model:\n', model, file=sys.stderr)
 
     trainer = Trainer(**targs)
 

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -728,6 +728,13 @@ class LazyWindowChunkedDIFile(DIFileFilter):
         self.starts = None
 
     def get_counts(self, orig=False):
+        """
+        Return the chunk counts for each sequence
+
+        Args:
+            orig (bool)     : return counts for sequence regardless of whether not
+                              this LazyWindowChunkedDIFile has been subsetting (with set_subset)
+        """
         if orig:
             counts = self.orig_lut.copy()
         else:

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+import copy
 import math
 import warnings
 
@@ -498,6 +499,9 @@ class DeepIndexFile(Container):
     def set_sequence_subset(self, indices=None):
         self.__indices = indices
         self.set_label_key(self.label_key)
+
+    def get_sequence_subset(self):
+        return copy.copy(self.__indices)
 
     def __translate_arg(self, arg):
         if self.__indices is None:

--- a/src/exabiome/utils.py
+++ b/src/exabiome/utils.py
@@ -146,13 +146,15 @@ def float_list(string):
     return _num_list(string, float)
 
 
-def distsplit(dset_len, size, rank):
+def distsplit(dset_len, size, rank, arange=True):
     q, r = divmod(dset_len, size)
     if rank < r:
         q += 1
         b = rank*q
-        return np.arange(b, b+q)
     else:
         offset = (q+1)*r
         b = (rank - r)*q + offset
+    if arange:
         return np.arange(b, b+q)
+    else:
+        return b, b+q


### PR DESCRIPTION
Two main things

- Inference and summary used to be run separately, resulting in a lot of unnecessary I/O. This PR merges them into a single step. Final outputs are stored for sequences. 
  - Because we rely on the magnitude of max. probabilities for identifying whether or not a classification is good, an option for saving these `-p`/`--maxprob`. 
- Custom training samplers and data loader was not returning correct lengths. This was breaking PL. 