### PR TITLE
Fix sampler iterator bug

### DIFF
--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -571,7 +571,7 @@ class DSSampler(Sampler):
             self.end = length
 
     def __iter__(self):
-        return range(self.start, self.end)
+        return iter(range(self.start, self.end))
 
     def __len__(self):
         return self.end - self.start

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -273,7 +273,11 @@ def process_args(args=None, return_io=False):
     del args.fp16
 
     if args.checkpoint is not None:
-        targs['resume_from_checkpoint'] = args.checkpoint
+        if os.path.exists(args.checkpoint):
+            targs['resume_from_checkpoint'] = args.checkpoint
+        else:
+            warnings.warn("Ignoring -c/--checkpoint argument because {args.checkpoint} does not exist.")
+            args.checkpoint = None
 
     if args.profile:
         targs['profiler'] = 'advanced'


### PR DESCRIPTION
Sampler was not returning iterator. 
- TIL that `range` is not an iterator. It is an iterable. To return it as an iterator, you must wrap it with a call to `iter`
- This caused jobs in the queue to fail. Dependencies require a checkpoint, which will not be there. To salvage the time these  jobs have spent in the queue, I made the training code ignore missing checkpoint files and start from scratch.