### PR TITLE
Unset Conda environment variables

### DIFF
--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -86,6 +86,7 @@ class AbstractJob(metaclass=ABCMeta):
         self.conda_env = None
         self.modules = list()
         self.debug = False
+        self.clear_var = set()
         self.env_vars = OrderedDict()
         self.to_export = dict()
         self.addl_job_flags = OrderedDict()
@@ -98,6 +99,9 @@ class AbstractJob(metaclass=ABCMeta):
     def add_modules(self, *module):
         for mod in module:
             self.modules.append(mod)
+
+    def unset_var(self, var):
+        self.clear_var.add(var)
 
     def set_env_var(self, var, value, export=None):
         '''Add an environment variable to be set in the shell script
@@ -188,6 +192,9 @@ class AbstractJob(metaclass=ABCMeta):
 
     def write(self, f, options=None):
         self.write_header(f, options)
+        print(file=f)
+        for var in self.clear_var:
+            print(f"unset {var}", file=f)
         print(file=f)
         for mod in self.modules:
             print(f'module load {mod}', file=f)

--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -193,7 +193,7 @@ class AbstractJob(metaclass=ABCMeta):
             print(f'module load {mod}', file=f)
         print(file=f)
         if self.conda_env:
-            print(f'source activate {self.conda_env}', file=f)
+            print(f'conda activate {self.conda_env}', file=f)
         print(file=f)
         for k, v in self.env_vars.items():
             export = "export " if self.to_export[k] else ""

--- a/src/exabiome/run/nersc.py
+++ b/src/exabiome/run/nersc.py
@@ -1,3 +1,5 @@
+import os
+
 from hdmf.utils import docval, getargs
 from .job import AbstractJob
 
@@ -47,6 +49,10 @@ class SlurmJob(AbstractJob):
         self.add_addl_jobflag('c', 10)
         self.add_addl_jobflag('-ntasks-per-node', self.gpus)
         self.add_addl_jobflag('-gpus-per-task', 1)
+
+        for k, v in os.environ.items():
+            if 'CONDA' in k:
+                self.unset_var(k)
 
         n_gpus = self.gpus
         self.use_bb = False

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -119,6 +119,7 @@ def run_train(argv=None):
         check_nersc(args)
         jobargs = get_jobargs(args)
         job = SlurmJob(**jobargs)
+        job.add_modules('python')
 
     if args.conda_env is None:
         args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)


### PR DESCRIPTION
When submitting a Slurm job from a conda environment, the job inherits the environment. I had to do some stuff so that the environment that gets passed in with the `-C` flag actually gets used.