### PR TITLE
Partition dataset

### DIFF
--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -79,6 +79,7 @@ def get_conf_args():
         'layers': dict(help='layers for an MLP model', default=None),
         'window': dict(type=int, help='the window size to use to chunk sequences', default=None),
         'step': dict(type=int, help='the step between windows. default is to use window size (i.e. non-overlapping chunks)', default=None),
+        'n_partitions': dict(type=int, help='the number of dataset partitions.', default=1),
         'fwd_only': dict(action='store_true', help='use forward strand of sequences only', default=False),
         'classify': dict(action='store_true', help='run a classification problem', default=False),
         'manifold': dict(action='store_true', help='run a manifold learning problem', default=False),

--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -136,8 +136,10 @@ class AbstractJob(metaclass=ABCMeta):
     def add_addl_jobflag(self, flag, val):
         self.addl_job_flags[flag] = val
 
-    def submit_job(self, path):
+    def submit_job(self, path, conda_env=None):
         cmd = f'{self.submit_cmd} {path}'
+        if conda_env is not None:
+            cmd = f'conda run -n {conda_env} {cmd}'
         print(cmd)
         output = subprocess.check_output(
                     cmd,

--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -86,6 +86,7 @@ class AbstractJob(metaclass=ABCMeta):
         self.conda_env = None
         self.modules = list()
         self.debug = False
+        self.clear_var = set()
         self.env_vars = OrderedDict()
         self.to_export = dict()
         self.addl_job_flags = OrderedDict()
@@ -98,6 +99,9 @@ class AbstractJob(metaclass=ABCMeta):
     def add_modules(self, *module):
         for mod in module:
             self.modules.append(mod)
+
+    def unset_var(self, var):
+        self.clear_var.add(var)
 
     def set_env_var(self, var, value, export=None):
         '''Add an environment variable to be set in the shell script
@@ -188,6 +192,9 @@ class AbstractJob(metaclass=ABCMeta):
 
     def write(self, f, options=None):
         self.write_header(f, options)
+        print(file=f)
+        for var in self.clear_var:
+            print(f"unset {var}", file=f)
         print(file=f)
         for mod in self.modules:
             print(f'module load {mod}', file=f)

--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -193,7 +193,7 @@ class AbstractJob(metaclass=ABCMeta):
             print(f'module load {mod}', file=f)
         print(file=f)
         if self.conda_env:
-            print(f'source activate {self.conda_env}', file=f)
+            print(f'conda activate {self.conda_env}', file=f)
         print(file=f)
         for k, v in self.env_vars.items():
             export = "export " if self.to_export[k] else ""

--- a/src/exabiome/run/nersc.py
+++ b/src/exabiome/run/nersc.py
@@ -1,3 +1,5 @@
+import os
+
 from hdmf.utils import docval, getargs
 from .job import AbstractJob
 
@@ -47,6 +49,10 @@ class SlurmJob(AbstractJob):
         self.add_addl_jobflag('c', 10)
         self.add_addl_jobflag('-ntasks-per-node', self.gpus)
         self.add_addl_jobflag('-gpus-per-task', 1)
+
+        for k, v in os.environ.items():
+            if 'CONDA' in k:
+                self.unset_var(k)
 
         n_gpus = self.gpus
         self.use_bb = False

--- a/src/exabiome/run/nersc.py
+++ b/src/exabiome/run/nersc.py
@@ -50,10 +50,6 @@ class SlurmJob(AbstractJob):
         self.add_addl_jobflag('-ntasks-per-node', self.gpus)
         self.add_addl_jobflag('-gpus-per-task', 1)
 
-        for k, v in os.environ.items():
-            if 'CONDA' in k:
-                self.unset_var(k)
-
         n_gpus = self.gpus
         self.use_bb = False
 

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -115,17 +115,18 @@ def run_train(argv=None):
         job.add_modules('open-ce')
         if not args.load:
             job.set_use_bb(True)
+        if args.conda_env is None:
+            args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
+
+        if args.conda_env != 'none':
+            job.set_conda_env(args.conda_env)
+        # set to none
+        args.conda_env = None
     else:
         check_nersc(args)
         jobargs = get_jobargs(args)
         job = SlurmJob(**jobargs)
-        job.add_modules('python')
 
-    if args.conda_env is None:
-        args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
-
-    if args.conda_env != 'none':
-        job.set_conda_env(args.conda_env)
 
     args.input = os.path.abspath(args.input)
 
@@ -281,7 +282,7 @@ def run_train(argv=None):
 
 
     def submit(job, shell, message):
-        job_id = job.submit_job(shell)
+        job_id = job.submit_job(shell, conda_env=args.conda_env)
         if job_id is None:
             print("unable to submit job")
         else:

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -119,6 +119,7 @@ def run_train(argv=None):
         check_nersc(args)
         jobargs = get_jobargs(args)
         job = SlurmJob(**jobargs)
+        job.add_modules('python')
 
     if args.conda_env is None:
         args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)


### PR DESCRIPTION
I added this in the interest of shortening epoch times. Instead of iterating over all overlapping chunks in an epoch, I added the ability to partition the overlapping chunks into non-overlapping partitions. 

- This can be accomplished by setting the config option `n_partitions` to `window // step`. Note that `window` must be divisible by `step`