### PR TITLE
Inference and model deployment

### DIFF
--- a/src/exabiome/__init__.py
+++ b/src/exabiome/__init__.py
@@ -59,6 +59,8 @@ def main():
             'test-input': Command('testing.dataset.check_sequences', 'Test input file against original fasta files'),
             'dset-info': Command('nn.loader.dataset_stats', 'Read a dataset and print the number of samples to stdout'),
             'extract-profile': Command('nn.summarize.get_profile_data', 'Extract profile data from log files'),
+            'conf-model': Command('nn.summarize.train_confidence_model', 'Train or convert a prediction confidence model'),
+            'deploy-pkg': Command('nn.deploy.build_deployment_pkg', 'Build Zip package for deploying model'),
         }
     }
     import sys

--- a/src/exabiome/__init__.py
+++ b/src/exabiome/__init__.py
@@ -24,6 +24,7 @@ def main():
             'count-sequence': Command('gtdb.prepare_data.count_sequence', 'Count the length of total sequence length for a set of accessions'),
             'sample-nonrep': Command('gtdb.sample.sample_nonrep', 'Get test strain genomes'),
             'sample-gtdb': Command('gtdb.sample.sample_tree', 'Sample taxa from a tree'),
+            'test-loaders': Command('nn.loader.check_loaded_sequences', 'load data and test that it is correct'),
         },
         'Training and models': {
             'train': Command('nn.train.run_lightning', 'Run training with PyTorch Lightning'),

--- a/src/exabiome/gtdb/make_fof.py
+++ b/src/exabiome/gtdb/make_fof.py
@@ -79,8 +79,11 @@ def make_fof(argv=None):
             with h5py.File(args.accessions, 'r') as f:
                 accessions = f['genome_table']['taxon_id'][:]
         else:
-            with open(args.accessions, 'r') as f:
-                accessions = f.readlines()
+            if os.path.exists(args.accessions):
+                with open(args.accessions, 'r') as f:
+                    accessions = f.readlines()
+            else:
+                accessions = [args.accessions]
 
         func = get_genomic_path
         if args.cds:

--- a/src/exabiome/gtdb/prepare_data.py
+++ b/src/exabiome/gtdb/prepare_data.py
@@ -321,6 +321,7 @@ def prepare_data(argv=None):
 
     comp = 'gzip' if args.gzip else None
     tmp_h5_filename = os.path.join(tmpdir, 'sequences.h5')
+    logger.info(f'writing temporary sequence data to {tmp_h5_filename}')
     tmp_h5_file = h5py.File(tmp_h5_filename, 'w')
     sequence = tmp_h5_file.create_dataset('sequences', shape=(total_seq_len,), dtype=np.uint8, compression=comp)
     seqindex = tmp_h5_file.create_dataset('sequences_index', shape=(n_seqs,), dtype=np.uint64, compression=comp)
@@ -348,17 +349,7 @@ def prepare_data(argv=None):
             b = e
             seq_i += 1
     ids = tmp_h5_file.create_dataset('ids', data=np.arange(n_seqs), dtype=int)
-    tmp_h5_file.close()
-
-    tmp_h5_file = h5py.File(tmp_h5_filename, 'r')
-    sequence = tmp_h5_file['sequences']
-    seqindex = tmp_h5_file['sequences_index']
-    genomes = tmp_h5_file['genomes']
-    seqlens = tmp_h5_file['seqlens']
-    names = tmp_h5_file['seqnames']
-    ids = tmp_h5_file['ids']
-
-
+    tmp_h5_file.flush()
 
     io = get_hdf5io(h5path, 'w')
 

--- a/src/exabiome/gtdb/prepare_data.py
+++ b/src/exabiome/gtdb/prepare_data.py
@@ -320,7 +320,8 @@ def prepare_data(argv=None):
         tmpdir = tempfile.mkdtemp()
 
     comp = 'gzip' if args.gzip else None
-    tmp_h5_file = h5py.File(os.path.join(tmpdir, 'sequences.h5'), 'w')
+    tmp_h5_filename = os.path.join(tmpdir, 'sequences.h5')
+    tmp_h5_file = h5py.File(tmp_h5_filename, 'w')
     sequence = tmp_h5_file.create_dataset('sequences', shape=(total_seq_len,), dtype=np.uint8, compression=comp)
     seqindex = tmp_h5_file.create_dataset('sequences_index', shape=(n_seqs,), dtype=np.uint64, compression=comp)
     genomes = tmp_h5_file.create_dataset('genomes', shape=(n_seqs,), dtype=np.uint64, compression=comp)
@@ -347,6 +348,17 @@ def prepare_data(argv=None):
             b = e
             seq_i += 1
     ids = tmp_h5_file.create_dataset('ids', data=np.arange(n_seqs), dtype=int)
+    tmp_h5_file.close()
+
+    tmp_h5_file = h5py.File(tmp_h5_filename, 'r')
+    sequence = tmp_h5_file['sequences']
+    seqindex = tmp_h5_file['sequences_index']
+    genomes = tmp_h5_file['genomes']
+    seqlens = tmp_h5_file['seqlens']
+    names = tmp_h5_file['seqnames']
+    ids = tmp_h5_file['ids']
+
+
 
     io = get_hdf5io(h5path, 'w')
 

--- a/src/exabiome/nn/infer.py
+++ b/src/exabiome/nn/infer.py
@@ -375,7 +375,7 @@ def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
                 k = outputs_q[0].shape[0] - args.maxprob
                 maxprobs = list()
                 for i in range(len(idx)):
-                    maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
+                    maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:])[::-1])
                 maxprob_dset[idx] = maxprobs
 
             if preds_dset is not None:
@@ -399,7 +399,7 @@ def parallel_chunked_inf_summ(model, dataset, args, addl_targs, fkwargs):
         k = outputs_q[0].shape[0] - args.maxprob
         maxprobs = list()
         for i in range(len(seqs_q)):
-            maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:]))
+            maxprobs.append(np.sort(np.partition(outputs_q[i], k)[k:])[::-1])
         maxprob_dset[seqs_q] = maxprobs
 
     if preds_dset is not None:

--- a/src/exabiome/nn/infer.py
+++ b/src/exabiome/nn/infer.py
@@ -49,7 +49,7 @@ def parse_args(*addl_args, argv=None):
     parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk or aggregation')
     parser.add_argument('-s', '--start', type=int, help='sample index to start at', default=0)
     # parser.add_argument('-a', '--aggregate', action='store_true', help='aggregate chunks within sequences', default=False)
-    parser.add_argument('-S', '--n_seqs', type=int, default=2500, help='the number of sequences to aggregate chunks for between each write to disk')
+    parser.add_argument('-S', '--n_seqs', type=int, default=500, help='the number of sequences to aggregate chunks for between each write to disk')
     parser.add_argument('-p', '--maxprob', metavar='TOPN', nargs='?', const=1, default=0, type=int,
                         help='store the top TOPN probablities of each output. By default, TOPN=1')
     parser.add_argument('-c', '--save_chunks', action='store_true', help='do store network outputs for each chunk', default=False)
@@ -205,7 +205,7 @@ def run_inference(argv=None):
         size = env.world_size()
 
         from mpi4py import MPI
-        args.logger.info(f' rank {rank} - Using MPI-IO')
+        args.logger.info(f'rank {rank} - Using MPI-IO')
         f_kwargs['driver'] = 'mpio'
         f_kwargs['comm'] = MPI.COMM_WORLD
 
@@ -244,7 +244,7 @@ def parallel_chunked_inf_summ(model, dataset, loader, args, fkwargs):
 
     # write what's in the to-write queues
     if not hasattr(args, 'n_seqs'):
-        args.n_seqs = 2500
+        args.n_seqs = 500
 
     # ensure that dataset is closed before we start up the DataLoader
     dataset.close()

--- a/src/exabiome/nn/infer.py
+++ b/src/exabiome/nn/infer.py
@@ -93,6 +93,7 @@ def process_args(args, comm=None):
 
     rank = 0
     size = 1
+    local_rank = 0
     env = None
 
     if args.slurm:
@@ -101,6 +102,7 @@ def process_args(args, comm=None):
         env = LSFEnvironment()
 
     if env is not None:
+        local_rank = env.local_rank()
         rank = env.global_rank()
         size = env.world_size()
 
@@ -179,7 +181,7 @@ def process_args(args, comm=None):
     ret = [model, dataset, loader, args, env]
 
     if size > 1:
-        args.device = torch.device('cuda:%d' % rank)
+        args.device = torch.device('cuda:%d' % local_rank)
     else:
         args.device = torch.device('cuda')
 

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -14,7 +14,7 @@ from sklearn.utils import check_random_state
 from hdmf.common import get_hdf5io
 
 from ..sequence import AbstractChunkedDIFile, WindowChunkedDIFile, LazyWindowChunkedDIFile, RevCompFilter, DeepIndexFile, chunk_sequence, lazy_chunk_sequence, DIFileFilter
-from ..utils import parse_seed, distsplit, get_logger
+from ..utils import parse_seed, distsplit, balsplit, get_logger
 
 import psutil
 import os
@@ -1017,7 +1017,7 @@ class LazySeqDataset(Dataset):
             self.orig_difile = self.io.read()
 
         if self._world_size > 1:
-            self.orig_difile.set_sequence_subset(distsplit(len(self.orig_difile), self._world_size, self._global_rank))
+            self.orig_difile.set_sequence_subset(balsplit(self.orig_difile.get_seq_lengths(), self._world_size, self._global_rank))
 
         self.difile = self.orig_difile
 

--- a/src/exabiome/nn/loader.py
+++ b/src/exabiome/nn/loader.py
@@ -8,7 +8,7 @@ import pytorch_lightning as pl
 import torch.nn.functional as F
 import torch
 import numpy as np
-from torch.utils.data import DataLoader, Dataset, Sampler, Subset
+from torch.utils.data import DataLoader, Dataset, Sampler, Subset, SequentialSampler
 from sklearn.model_selection import train_test_split
 from sklearn.utils import check_random_state
 from hdmf.common import get_hdf5io
@@ -679,7 +679,7 @@ class WORSampler(Sampler):
         return ret
 
 
-class DSSampler(Sampler):
+class DSSampler(SequentialSampler):
     """Distributed Sequential Sampler"""
 
     def __init__(self, length, rank=0, size=1, n_partitions=1, part_smplr_rng=None):

--- a/src/exabiome/nn/models/lit.py
+++ b/src/exabiome/nn/models/lit.py
@@ -126,7 +126,7 @@ class AbstractLit(LightningModule):
         output = self.forward(seqs)
         loss = self._loss(output, target)
         if self.hparams.classify:
-            self.log(self.train_acc, self.accuracy(output, target))
+            self.log(self.train_acc, self.accuracy(output, target), prog_bar=True)
         self.log(self.train_loss, loss)
         self.log('time', time())
         return loss
@@ -140,7 +140,7 @@ class AbstractLit(LightningModule):
         output = self(seqs)
         loss = self._loss(output, target)
         if self.hparams.classify:
-            self.log(self.val_acc, self.accuracy(output, target))
+            self.log(self.val_acc, self.accuracy(output, target), prog_bar=True)
         self.log(self.val_loss, loss)
         self.log('time', time())
         return loss

--- a/src/exabiome/nn/train.py
+++ b/src/exabiome/nn/train.py
@@ -79,6 +79,7 @@ def get_conf_args():
         'layers': dict(help='layers for an MLP model', default=None),
         'window': dict(type=int, help='the window size to use to chunk sequences', default=None),
         'step': dict(type=int, help='the step between windows. default is to use window size (i.e. non-overlapping chunks)', default=None),
+        'n_partitions': dict(type=int, help='the number of dataset partitions.', default=1),
         'fwd_only': dict(action='store_true', help='use forward strand of sequences only', default=False),
         'classify': dict(action='store_true', help='run a classification problem', default=False),
         'manifold': dict(action='store_true', help='run a manifold learning problem', default=False),

--- a/src/exabiome/run/job.py
+++ b/src/exabiome/run/job.py
@@ -136,8 +136,10 @@ class AbstractJob(metaclass=ABCMeta):
     def add_addl_jobflag(self, flag, val):
         self.addl_job_flags[flag] = val
 
-    def submit_job(self, path):
+    def submit_job(self, path, conda_env=None):
         cmd = f'{self.submit_cmd} {path}'
+        if conda_env is not None:
+            cmd = f'conda run -n {conda_env} {cmd}'
         print(cmd)
         output = subprocess.check_output(
                     cmd,

--- a/src/exabiome/run/nersc.py
+++ b/src/exabiome/run/nersc.py
@@ -50,10 +50,6 @@ class SlurmJob(AbstractJob):
         self.add_addl_jobflag('-ntasks-per-node', self.gpus)
         self.add_addl_jobflag('-gpus-per-task', 1)
 
-        for k, v in os.environ.items():
-            if 'CONDA' in k:
-                self.unset_var(k)
-
         n_gpus = self.gpus
         self.use_bb = False
 

--- a/src/exabiome/run/run_infer.py
+++ b/src/exabiome/run/run_infer.py
@@ -43,7 +43,7 @@ def run_inference(argv=None):
     parser.add_argument('-M', '--in_memory', default=False, action='store_true', help='collect all batches in memory before writing to disk')
     parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk')
     parser.add_argument('-s', '--start', type=int, help='sample index to start at', default=None)
-    parser.add_argument('-S', '--n_seqs', type=int, default=2500, help='the number of sequences to aggregate chunks for between each write to disk')
+    parser.add_argument('-S', '--n_seqs', type=int, default=500, help='the number of sequences to aggregate chunks for between each write to disk')
     parser.add_argument('-p', '--maxprob', metavar='TOPN', nargs='?', const=1, default=0, type=int,
                         help='store the top TOPN probablities of each output. By default, TOPN=1')
     parser.add_argument('-c', '--save_chunks', action='store_true', help='save network outputs for all chunks', default=False)

--- a/src/exabiome/run/run_infer.py
+++ b/src/exabiome/run/run_infer.py
@@ -43,6 +43,9 @@ def run_inference(argv=None):
     parser.add_argument('-M', '--in_memory', default=False, action='store_true', help='collect all batches in memory before writing to disk')
     parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk')
     parser.add_argument('-s', '--start', type=int, help='sample index to start at', default=None)
+    parser.add_argument('-S', '--n_seqs', type=int, default=2500, help='the number of sequences to aggregate chunks for between each write to disk')
+    parser.add_argument('-p', '--maxprob', metavar='TOPN', nargs='?', const=1, default=0, type=int,
+                        help='store the top TOPN probablities of each output. By default, TOPN=1')
     parser.add_argument('-c', '--save_chunks', action='store_true', help='save network outputs for all chunks', default=False)
 
     parser.add_argument('-d', '--debug',        help="submit to debug queue", action='store_true', default=False)
@@ -64,10 +67,13 @@ def run_inference(argv=None):
 
     options = ''
 
-    options = f'{options} -b {args.batch_size} -B {args.n_batches} -k {args.num_workers} '
+    options = f'{options} -b {args.batch_size} -B {args.n_batches} -k {args.num_workers} -S {args.n_seqs} '
+
+    if args.maxprob > 0:
+        options += f'-p {args.maxprob} '
 
     if args.start != None:
-        options += f'{args.start} '
+        options += f'-s {args.start} '
 
     if args.save_chunks:
         options += f'-c '

--- a/src/exabiome/run/run_infer.py
+++ b/src/exabiome/run/run_infer.py
@@ -9,22 +9,19 @@ from .utils import get_job
 from ..utils import get_seed, check_argv
 
 
-def run_train(argv=None):
+def run_inference(argv=None):
     argv = check_argv(argv)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('input', help='the input file to use')
-    parser.add_argument('config', help='the config file to use')
+    parser.add_argument('checkpoint', help='the model checkpoint to use')
     parser.add_argument('sh', nargs='?', help='a path to write the shell script to')
 
-    parser.add_argument('-o', '--outdir',      help="the output directory", default=None)
+    parser.add_argument('-F', '--config',      help='the config file to use', default=None)
     parser.add_argument('-m', '--message',     help="message to write to log file", default=None)
     parser.add_argument('-L', '--log',         help="the log file to store run information in", default='jobs.log')
     parser.add_argument('--submit',            help="submit job to queue", action='store_true', default=False)
-    prof_grp = parser.add_mutually_exclusive_group()
-    prof_grp.add_argument('--profile', action='store_true', default=False, help='profile with PyTorch Lightning profile')
-    prof_grp.add_argument('--cuda_profile', action='store_true', default=False, help='profile with PyTorch CUDA profiling')
-    parser.add_argument('-a', '--chain',       help="chain jobs in submission", type=int, default=1)
+    #parser.add_argument('-a', '--chain',       help="chain jobs in submission", type=int, default=1)
 
     rsc_grp = parser.add_argument_group('Resource Manager Arguments')
     rsc_grp.add_argument('-T', '--time',       help='the time to run the job for', default='01:00:00')
@@ -40,145 +37,58 @@ def run_train(argv=None):
     grp.add_argument('--perlmutter',  help='make script for running on NERSC Perlmutter',  action='store_true', default=False)
     grp.add_argument('--summit',      help='make script for running on OLCF Summit', action='store_true', default=False)
 
+    parser.add_argument('--nonrep', action='store_true', default=False, help='the dataset is nonrepresentative species')
+    parser.add_argument('-b', '--batch_size', type=int, help='batch size', default=64)
     parser.add_argument('-k', '--num_workers', type=int, help='the number of workers to load data with', default=1)
-    parser.add_argument('-y', '--pin_memory', action='store_true', default=False, help='pin memory when loading data')
-    parser.add_argument('-f', '--shuffle', action='store_true', default=False, help='shuffle batches when training')
-    parser.add_argument('-D', '--dataset',      help="the dataset name", default='default')
-    parser.add_argument('-e', '--epochs',       help="the number of epochs to run for", default=10)
-    parser.add_argument('-c', '--checkpoint',   help="a checkpoint file to restart from", default=None)
-    parser.add_argument('-i', '--init',         help="a checkpoint file to initialize models from", default=None)
-    parser.add_argument('-F', '--features',     help="a checkpoint file for features", default=None)
-    parser.add_argument('-E', '--experiment',   help="the experiment name to use", default=None)
+    parser.add_argument('-M', '--in_memory', default=False, action='store_true', help='collect all batches in memory before writing to disk')
+    parser.add_argument('-B', '--n_batches', type=int, default=100, help='the number of batches to accumulate between each write to disk')
+    parser.add_argument('-s', '--start', type=int, help='sample index to start at', default=None)
+    parser.add_argument('-c', '--save_chunks', action='store_true', help='save network outputs for all chunks', default=False)
+
     parser.add_argument('-d', '--debug',        help="submit to debug queue", action='store_true', default=False)
-    parser.add_argument('-s', '--sanity', metavar='NBAT', nargs='?', const=True, default=False,
-                        help='run NBAT batches for training and NBAT//4 batches for validation. By default, NBAT=4000')
-    parser.add_argument('--early_stop',         help="use PL early stopping", action='store_true', default=False)
-    parser.add_argument('--swa', action='store_true', default=False, help='use stochastic weight averaging')
-    parser.add_argument('-l', '--load',         help="load dataset into memory", action='store_true', default=False)
+
     parser.add_argument('-C', '--conda_env',    help=("the conda environment to use. use 'none' "
                                                       "if no environment loading is desired"), default=None)
 
     args = parser.parse_args(argv)
 
-    with open(args.config, 'r') as f:
-        conf = yaml.safe_load(f)
 
+    job = get_job(args)
 
-    if conf.get('optimizer', "").startswith('adam') and conf.get('lr_scheduler', '') == 'cyclic':
-        print("Cannot use cyclic LR scheduler with Adam/AdamW", file=sys.stderr)
-        exit(1)
+    outdir = os.path.splitext(args.checkpoint)[0] + ('.nonrep' if args.nonrep else '.rep')
+    if not os.path.exists(outdir):
+        os.mkdir(outdir)
 
-    if conf.get('seed', None) is None:
-        conf["seed"] = get_seed()
-
-
-    args.input = os.path.abspath(args.input)
+    if args.config is None:
+        args.config = os.path.dirname(args.checkpoint) + ".yml"
 
     options = ''
-    if args.debug:
-        job.set_debug(True)
 
-    if args.sanity:
-        options = '--sanity'
-        if isinstance(args.sanity, str):
-            options += f' {args.sanity}'
+    options = f'{options} -b {args.batch_size} -B {args.n_batches} -k {args.num_workers} '
 
-    if args.early_stop:
-        options += f' --early_stop'
+    if args.start != None:
+        options += f'{args.start} '
 
-    if args.swa:
-        options += f' --swa'
+    if args.save_chunks:
+        options += f'-c '
 
-    if args.profile:
-        options += f' --profile'
-    elif args.cuda_profile:
-        options += f' --cuda_profile'
-
-    chunks = f'chunks_W{conf["window"]}_S{conf["step"]}'
-
-    L = None
-    if conf.get('manifold', False):
-        L = 'M'
-    elif conf.get('classify', False):
-        L = 'C'
-    else:
-        raise ValueError("did not find 'classify' or 'manifold' in config file")
-
-    options = (f'{options} -g {args.gpus} -n {args.nodes} -e {args.epochs} '
-               f'-k {args.num_workers}')
-
-    if "n_outputs" in conf:
-        exp = f'n{args.nodes}_g{args.gpus}_A{conf["accumulate"]}_b{conf["batch_size"]}_r{conf["lr"]}_o{conf["n_outputs"]}_O{conf["optimizer"]}'
-    else:
-        exp = f'n{args.nodes}_g{args.gpus}_A{conf["accumulate"]}_b{conf["batch_size"]}_r{conf["lr"]}_{conf["tgt_tax_lvl"]}_O{conf["optimizer"]}'
-
-    if args.pin_memory:
-        options += ' -y'
-
-    if args.shuffle:
-        options += ' -f'
-
-    if args.load:
-        options += f' -l'
-
-    if conf.get('lr_scheduler', None) is not None:
-        exp += f'_{conf["lr_scheduler"]}'
-
-    if args.checkpoint:
-        if not args.checkpoint.endswith('.ckpt'):
-            args.checkpoint = os.path.join(args.checkpoint, 'last.ckpt')
-        if not os.path.exists(args.checkpoint) or os.path.isdir(args.checkpoint):
-            # assume we are supposed ot wait for the job to finish
-            # to get the checkpoint from
-            if os.path.isdir(args.checkpoint):
-                jobdir = args.checkpoint
-                args.checkpoint = os.path.join(args.checkpoint, 'last.ckpt')
-            else:
-                jobdir = os.path.dirname(args.checkpoint)
-            job_dep = jobdir[jobdir.rfind('.')+1:].strip("/")
-            if args.summit:
-                job_dep = f'ended({job_dep})'
-            elif (args.cori or args.perlmutter):
-                job_dep = f'afterok:{job_dep}'
-            job.add_addl_jobflag(job.wait_flag, job_dep)
-        job.set_env_var('CKPT', args.checkpoint)
-        options += f' -c $CKPT'
-    elif args.init:
-        job.set_env_var('CKPT', args.init)
-        options += f' -i $CKPT'
-    elif args.chain > 1:
-        job.set_env_var('CKPT', '')
-
-
-    if args.features:
-        job.set_env_var('FEATS_CKPT', args.features)
-        options += f' -F $FEATS_CKPT'
-
-    if args.experiment:
-        exp = args.experiment
-
-    options += f' -E {exp}'
-
-
-
-    expdir = f'{args.outdir}/train/datasets/{args.dataset}/{chunks}/{conf["model"]}/{L}/{exp}'
-    if not os.path.exists(expdir):
-        os.makedirs(expdir)
-
-    job.output = f'{expdir}/train.%{job.job_fmt_var}.log'
+    job.output = f'{outdir}/infer.%{job.job_fmt_var}.log'
     job.error = job.output
 
     job.set_env_var('OMP_NUM_THREADS', 1)
 
-    job.set_env_var('OPTIONS', options)
-    job.set_env_var('OUTDIR', f'{expdir}/train.$JOB')
-    job.set_env_var('CONF', f'{expdir}/train.$JOB.yml')
+    job.set_env_var('OUTDIR', f'{outdir}/infer.$JOB')
+    job.set_env_var('CONF', args.config)
     job.set_env_var('INPUT', args.input)
+    job.set_env_var('CKPT', args.checkpoint)
     job.set_env_var('LOG', '$OUTDIR.log')
+    job.set_env_var('OUTPUT', '$OUTDIR/outputs.h5')
+    options += '-o $OUTPUT'
+    job.set_env_var('OPTIONS', options)
 
     input_var = 'INPUT'
 
-    train_cmd = 'deep-taxon train'
+    train_cmd = 'deep-taxon infer'
     if args.summit:
         train_cmd += ' --lsf'
         if job.use_bb:
@@ -201,7 +111,7 @@ def run_train(argv=None):
             job.add_command('ls $BB_INPUT') #, run='jsrun -n 1')
 
 
-    train_cmd += f' $OPTIONS $CONF ${input_var} $OUTDIR'
+    train_cmd += f' $OPTIONS $CONF ${input_var} $CKPT'
 
     job.set_env_var('CMD', train_cmd)
 
@@ -220,8 +130,6 @@ def run_train(argv=None):
         job.add_command('$CMD >> $LOG 2>&1', run=jsrun)
     else:
         srun = 'srun'
-        if args.cuda_profile:
-            srun += ' nsys profile -t nvtx,cuda --output=$OUTDIR/nsys_report.%h.%p.h5 --export=hdf --stats=true'
         job.add_command('$CMD >> $LOG 2>&1', run=srun)
 
 
@@ -230,12 +138,8 @@ def run_train(argv=None):
         if job_id is None:
             print("unable to submit job")
         else:
-            jobdir = f'{expdir}/train.{job_id}'
+            jobdir = f'{outdir}/infer.{job_id}'
             print(f'running job out of {jobdir}')
-            cfg_path = f'{jobdir}.yml'
-            print(f'writing config file to {cfg_path}')
-            with open(cfg_path, 'w') as f:
-                yaml.main.safe_dump(conf, f, default_flow_style=False)
             dest = f'{jobdir}.sh'
             print(f'copying submission script to {os.path.relpath(dest)}')
             logpath = os.path.relpath(f'{jobdir}.log')
@@ -254,6 +158,7 @@ def run_train(argv=None):
                 print('-------------------------------------------------------------------------------', file=logout)
         return job_id, jobdir, message
 
+    args.chain = 1
     if args.sh is not None:
         if args.submit:
             msg = args.message

--- a/src/exabiome/run/run_infer.py
+++ b/src/exabiome/run/run_infer.py
@@ -138,6 +138,8 @@ def run_inference(argv=None):
         srun = 'srun'
         job.add_command('$CMD >> $LOG 2>&1', run=srun)
 
+    job.add_command('echo "==== Computing taxonomic accuracy ====" >> $LOG')
+    job.add_command('deep-taxon tax-acc $OUTPUT $INPUT $OUTDIR/tax_acc.csv >> $LOG 2>&1')
 
     def submit(job, shell, message):
         job_id = job.submit_job(shell, conda_env=args.conda_env)

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -115,17 +115,18 @@ def run_train(argv=None):
         job.add_modules('open-ce')
         if not args.load:
             job.set_use_bb(True)
+        if args.conda_env is None:
+            args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
+
+        if args.conda_env != 'none':
+            job.set_conda_env(args.conda_env)
+        # set to none
+        args.conda_env = None
     else:
         check_nersc(args)
         jobargs = get_jobargs(args)
         job = SlurmJob(**jobargs)
-        job.add_modules('python')
 
-    if args.conda_env is None:
-        args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
-
-    if args.conda_env != 'none':
-        job.set_conda_env(args.conda_env)
 
     args.input = os.path.abspath(args.input)
 
@@ -281,7 +282,7 @@ def run_train(argv=None):
 
 
     def submit(job, shell, message):
-        job_id = job.submit_job(shell)
+        job_id = job.submit_job(shell, conda_env=args.conda_env)
         if job_id is None:
             print("unable to submit job")
         else:

--- a/src/exabiome/run/run_job.py
+++ b/src/exabiome/run/run_job.py
@@ -60,6 +60,8 @@ def run_train(argv=None):
 
     args = parser.parse_args(argv)
 
+    job = get_job(args)
+
     with open(args.config, 'r') as f:
         conf = yaml.safe_load(f)
 

--- a/src/exabiome/run/utils.py
+++ b/src/exabiome/run/utils.py
@@ -54,4 +54,8 @@ def get_job(args):
         jobargs = get_jobargs(args)
         job = SlurmJob(**jobargs)
 
+    job.add_command('echo "=== exabiome package ===" >> $LOG')
+    job.add_command("pip show exabiome >> $LOG")
+    job.add_command('echo "========================" >> $LOG')
+
     return job

--- a/src/exabiome/run/utils.py
+++ b/src/exabiome/run/utils.py
@@ -1,0 +1,57 @@
+from .summit import LSFJob
+from .nersc import SlurmJob
+
+
+def check_summit(args):
+    if args.gpus is None:
+        args.gpus = 6
+    if args.nodes is None:
+        args.nodes = 2
+    if args.outdir is None:
+        args.outdir = os.path.realpath(os.path.expandvars("$PROJWORK/bif115/../scratch/$USER/deep-taxon"))
+    if args.conda_env is None:
+        args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
+        if args.conda_env is None:
+            raise RuntimeError("Cannot determine the conda environment to use")
+        #args.conda_env = 'exabiome-wml-1.7.0-3'
+
+
+def check_nersc(args):
+    if args.gpus is None:
+        args.gpus = 4
+    if args.nodes is None:
+        args.nodes = 1
+    # if args.outdir is None:
+    #     args.outdir = os.path.abspath(os.path.expandvars("$SCRATCH/exabiome/deep-taxon"))
+    if args.queue is None:
+        args.queue = 'regular'
+
+
+def get_jobargs(args):
+    return {k: getattr(args, k) for k in ('queue', 'nodes', 'gpus', 'jobname', 'project', 'time')}
+
+
+def get_job(args):
+    """
+    Figure out which Job type to use and set up necessary job environment configurations.
+    """
+    if args.summit:
+        check_summit(args)
+        jobargs = get_jobargs(args)
+        job = LSFJob(**jobargs)
+        job.add_modules('open-ce')
+        if not args.load:
+            job.set_use_bb(True)
+        if args.conda_env is None:
+            args.conda_env = os.environ.get('CONDA_DEFAULT_ENV', None)
+
+        if args.conda_env != 'none':
+            job.set_conda_env(args.conda_env)
+        # set to none
+        args.conda_env = None
+    else:
+        check_nersc(args)
+        jobargs = get_jobargs(args)
+        job = SlurmJob(**jobargs)
+
+    return job

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -858,7 +858,7 @@ class RevCompFilter(DIFileFilter):
 
 class DIFileManager:
 
-    def __init__(self, path, comm=None, load_data=False, tgt_tax_lvl, rank=0, size=1):
+    def __init__(self, path, tgt_tax_lvl, comm=None, load_data=False, rank=0, size=1):
         self.path = path
         self.comm = comm
         self.load_data = load_data

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -489,10 +489,12 @@ class DeepIndexFile(Container):
         return self.get(i)
 
     def get(self, arg):
+        # we don't need to translate the argument for labels, since
+        # labels is already dereferenced (see set_label_key)
+        label = self.labels[arg]
         arg = self.__translate_arg(arg)
         idx = self.seq_table.id[arg]
         seq = self.seq_table['sequence'].get(arg, index=True)   # sequence data
-        label = self.labels[arg]
         length = self.seq_table['length'].get(arg)
         return {'id': idx, 'seq': seq, 'label': label, 'length': length}
 

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -489,11 +489,9 @@ class DeepIndexFile(Container):
         return self.get(i)
 
     def get(self, arg):
-        # we don't need to translate the argument for labels, since
-        # labels is already dereferenced (see set_label_key)
-        label = self.labels[arg]
         arg = self.__translate_arg(arg)
         idx = self.seq_table.id[arg]
+        label = self.genome_table['rep_idx'].get(self.seq_table['genome'].get(arg, index=True), index=True)
         seq = self.seq_table['sequence'].get(arg, index=True)   # sequence data
         length = self.seq_table['length'].get(arg)
         return {'id': idx, 'seq': seq, 'label': label, 'length': length}
@@ -789,7 +787,7 @@ class LazyWindowChunkedDIFile(DIFileFilter):
 
         item = self.difile[seq_i]
         item['seq'] = item['seq'][s:e]
-        item['seq_idx'] = seq_i
+        item['seq_idx'] = item['id']
         item['id'] = i
         item['length'] = e - s
         return item

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -849,7 +849,7 @@ class RevCompFilter(DIFileFilter):
         item = self.difile[arg]
         try:
             if rev:
-                item['seq'] = self.rcmap[item['seq'].astype(int)]
+                item['seq'] = self.rcmap[item['seq'].astype(int)].flip(0)
         except AttributeError as e:
             raise ValueError("Cannot run without loading data. Use -l to load data") from e
         item['id'] = oarg if oarg >= 0 else len(self) + oarg

--- a/src/exabiome/sequence/dna_table.py
+++ b/src/exabiome/sequence/dna_table.py
@@ -854,3 +854,42 @@ class RevCompFilter(DIFileFilter):
             raise ValueError("Cannot run without loading data. Use -l to load data") from e
         item['id'] = oarg if oarg >= 0 else len(self) + oarg
         return item
+
+
+class DIFileManager:
+
+    def __init__(self, path, comm=None, load_data=False, tgt_tax_lvl, rank=0, size=1):
+        self.path = path
+        self.comm = comm
+        self.load_data = load_data
+        self.difile = None
+        self._world_size = size
+        self._global_rank = rank
+        self.tgt_tax_lvl = tgt_tax_lvl
+
+    def open(self):
+        """Open the HDMF file and set up chunks and taxonomy label"""
+        if self.comm is not None:
+            self.io = get_hdf5io(self.path, 'r', comm=self.comm, driver='mpio')
+        else:
+            self.io = get_hdf5io(self.path, 'r')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.difile = self.io.read()
+
+        if self._world_size > 1:
+            self.difile.set_sequence_subset(distsplit(len(self.difile), self._world_size, self._global_rank))
+
+        self.load(sequence=self.load_data)
+
+        self.difile.set_label_key(self.tgt_tax_lvl)
+
+    def load(self, sequence=False, device=None):
+        _load = lambda x: x[:]
+        self.difile.seq_table['id'].transform(_load)
+        self.difile.seq_table['length'].transform(lambda x: x[:].astype(int))
+        self.difile.seq_table['sequence_index'].transform(_load)
+        if sequence:
+            self.difile.seq_table['sequence_index'].target.transform(_load)
+
+

--- a/src/exabiome/utils.py
+++ b/src/exabiome/utils.py
@@ -158,3 +158,23 @@ def distsplit(dset_len, size, rank, arange=True):
         return np.arange(b, b+q)
     else:
         return b, b+q
+
+def balsplit(weights, size, rank):
+    """
+    Get a balanced partition from weighted data
+    for rank *rank* when world size is *size*
+    """
+    srt = np.argsort(weights)
+    s = 0
+    e = len(srt) - 1
+    curr = 0
+    ids = [list() for i in range(size)]
+    while s < e:
+        ids[curr].append(srt[s])
+        ids[curr].append(srt[e])
+        s += 1
+        e -= 1
+        curr = (curr + 1) % size
+    if s == e:
+        ids[size - 1].append(srt[s])
+    return np.array(np.sort(ids[rank]))


### PR DESCRIPTION
This PR contains many things related to inference and model deployment

- Three new commands:
  - `test-loaders`: This command tests reading data from loaders used for training
  - `conf-model`: This command builds a logistic regression model for classifying neural network predictions as good/bad
  - `deploy-pkg`: This command builds a zip archive of all files needed for deploying `gtnet`
  - `infer-job`: This commands builds a script for running an inference job and submits it
- Work out kinks in parallel inference code
  - Load balance sequences more effectively (see `exabiome.utils.balsplit`)
- Fix data conversion bug. HDMF was copying over temporary files before they were finished writing. The fix was flushing the tempfile buffers before passing them to HDMFIO
- Clean up inference code and get rid of old code.