### PR TITLE
updated nersc.py

### DIFF
--- a/src/deep_taxon/run/nersc.py
+++ b/src/deep_taxon/run/nersc.py
@@ -46,7 +46,7 @@ class SlurmJob(AbstractJob):
             arch = 'haswell'
         self.add_addl_jobflag('C', arch)
         #self.add_addl_jobflag('G', self.gpus)
-        self.add_addl_jobflag('c', 10)
+        self.add_addl_jobflag('-cpus-per-task', int(2*[64/self.gpus]))
         self.add_addl_jobflag('-ntasks-per-node', self.gpus)
         self.add_addl_jobflag('-gpus-per-node', 4)
 


### PR DESCRIPTION
this file is now updated to appropriately set cpus-per-task on perlmutter -- this allows you to  utilize multi-gpu training.

https://docs.nersc.gov/systems/perlmutter/running-jobs/#specify-the-number-of-logical-cpus-per-task-on-cpu