### PR TITLE
Add no-lightning implementation of training

### DIFF
--- a/src/deep_taxon/nn/no_lightning.py
+++ b/src/deep_taxon/nn/no_lightning.py
@@ -121,6 +121,7 @@ class Trainer:
             self.train_data = self.data_mod.train_dataloader()
         b_sz = len(next(iter(self.train_data))[0])
         print(f"[GPU{self.global_rank}] Epoch {epoch} | Batchsize: {b_sz} | Steps: {len(self.train_data)}")
+        it = self.train_data
         if self.global_rank == 0:
             it = tqdm(self.train_data, desc=f"Epoch {epoch}") #, leave=False)
         avg_loss = self._run_loop(epoch, it)
@@ -132,6 +133,7 @@ class Trainer:
     def _run_validate(self, epoch):
         if self.validate_data is None:
             self.validate_data = self.data_mod.val_dataloader()
+        it = self.validate_data
         if self.global_rank == 0:
             it = tqdm(self.validate_data, desc=f"Validation epoch {epoch}") #, leave=False)
         avg_loss = self._run_loop(epoch, it)

--- a/src/deep_taxon/nn/no_lightning.py
+++ b/src/deep_taxon/nn/no_lightning.py
@@ -1,11 +1,47 @@
+from collections import deque
 import os
 import shutil
+from time import time
 
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.distributed as dist
 
 from tqdm import tqdm
+
+class RunningAverage:
+
+    def __init__(self, max_samples=None):
+        self._avg = 0.0
+        self._n = 0
+        self.max_samples = max_samples
+        self._samples = deque()
+
+    @property
+    def avg(self):
+        if self.max_samples:
+            return sum(self._samples)/len(self._samples)
+        else:
+            return self._avg
+
+    def update(self, loss):
+        loss = float(loss)
+        if self.max_samples:
+            self._samples.append(loss)
+            if len(self._samples) > self.max_samples:
+                self._samples.popleft()
+        else:
+            self._avg =  (self._n * self._avg + loss) / (self._n + 1)
+            self._n += 1
+
+    def __repr__(self):
+        return str(self.avg)
+
+    def __format__(self, s):
+        return format(self.avg, s)
+
+    def __float__(self):
+        return self.avg
 
 class Trainer:
     def __init__(self, model, targs, data_mod, output_dir):
@@ -25,15 +61,19 @@ class Trainer:
             self.optimizer = self.optimizer[0][0]
         self.epochs_run = 0
         self.snapshot_path = f"{output_dir}/last.ckpt"
+        self.metrics_path = f"{output_dir}/metrics.csv"
 
         self.best_path = None
         self.best_loss = float('inf')
+        self.step = 0
         self.output_dir = output_dir
 
         if os.path.exists(self.snapshot_path):
             print(f"Loading snapshot from {self.snapshot_path}")
-            self._load_snapshot(snapshot_path)
+            self._load_snapshot(self.snapshot_path)
 
+        self._n_loss_samples = 100
+        self._log_interval = self._n_loss_samples
 
     def _load_snapshot(self, snapshot_path):
         snapshot = torch.load(snapshot_path)
@@ -41,6 +81,7 @@ class Trainer:
         self.best_loss = snapshot["LOSS"]
         self.epochs_run = snapshot["EPOCHS_RUN"]
         self.optimizer = snapshot["OPTIMIZER"]
+        self.step = snapshot['STEP']
         self.scheduler = snapshot.get("SCHEDULER", None)
         print(f"Resuming training from snapshot at Epoch {self.epochs_run}")
 
@@ -54,43 +95,55 @@ class Trainer:
             self.optimizer.step()
         return loss
 
+    def _run_loop(self, epoch, it):
+        avg = RunningAverage(self._n_loss_samples)
+        time_avg = RunningAverage(self._n_loss_samples)
+        s = time()
+        for i, (source, targets) in enumerate(it):
+            self.step += 1
+            source = source.to(self.local_rank)
+            targets = targets.to(self.local_rank)
+            avg.update(self._run_batch(source, targets))
+            if isinstance(it, tqdm):
+                it.set_postfix(loss=f"{avg:0.8f}")
+            e = time()
+            time_avg.update(e - s)
+            s = e
+            if self.global_rank == 0 and i % self._log_interval == 0:
+                phase = 'train' if torch.is_grad_enabled() else 'val'
+                print(",".join([str(x) for x in (self.step, phase, avg, time_avg)]), file=self.metrics_file)
+        return float(avg)
+
+
     @torch.enable_grad()
     def _run_train(self, epoch):
         if self.train_data is None:
             self.train_data = self.data_mod.train_dataloader()
         b_sz = len(next(iter(self.train_data))[0])
         print(f"[GPU{self.global_rank}] Epoch {epoch} | Batchsize: {b_sz} | Steps: {len(self.train_data)}")
-        it = self.train_data
         if self.global_rank == 0:
-            it = tqdm(it, desc=f"Epoch {epoch}", leave=False)
-        for source, targets in it:
-            source = source.to(self.local_rank)
-            targets = targets.to(self.local_rank)
-            self._run_batch(source, targets)
+            it = tqdm(self.train_data, desc=f"Epoch {epoch}") #, leave=False)
+        avg_loss = self._run_loop(epoch, it)
         if self.scheduler is not None:
             self.scheduler.step()
-
-        return None
+        return avg_loss
 
     @torch.no_grad()
     def _run_validate(self, epoch):
         if self.validate_data is None:
-            self.validate_data = self.data_mod.validate_dataloader()
-        it = self.validate_data
+            self.validate_data = self.data_mod.val_dataloader()
         if self.global_rank == 0:
-            it = tqdm(it, desc=f"Validation epoch {epoch}", leave=False)
-        for source, targets in it:
-            source = source.to(self.local_rank)
-            targets = targets.to(self.local_rank)
-            self._run_batch(source, targets)
-        return None
+            it = tqdm(self.validate_data, desc=f"Validation epoch {epoch}") #, leave=False)
+        avg_loss = self._run_loop(epoch, it)
+        return avg_loss
 
-    def _save_snapshot(self, epoch, valid_loss):
+    def _save_snapshot(self, epoch, valid_loss, step):
         snapshot = {
             "MODEL_STATE": self.model.module.state_dict(),
-            "EPOCHS_RUN": epoch,
+            "EPOCHS_RUN": epoch + 1,
             "OPTIMIZER": self.optimizer,
             "LOSS": valid_loss,
+            "STEP": step,
         }
         if self.scheduler is not None:
             snapshot['SCHEDULER'] = self.scheduler
@@ -109,11 +162,20 @@ class Trainer:
     def train(self, max_epochs: int):
         dist.init_process_group(backend="nccl", rank=self.global_rank, world_size=self.world_size)
         self.model = DDP(self.model, device_ids=[self.local_rank])
+        if self.global_rank == 0:
+            if os.path.exists(self.metrics_path):
+                self.metrics_file = open(self.metrics_path, 'a')
+            else:
+                self.metrics_file = open(self.metrics_path, 'w')
+                print("step,phase,loss,rate", file=self.metrics_file)
+
         for epoch in range(self.epochs_run, max_epochs):
             self._run_train(epoch)
-            valid_loss = self._run_validate()
-            if self.local_rank == 0:
-                self._save_snapshot(epoch, valid_loss)
+            valid_loss = self._run_validate(epoch)
+            if self.global_rank == 0:
+                self._save_snapshot(epoch, valid_loss, self.step)
             dist.barrier()
-        self.model = self.model.model
+        self.model = self.model.module
+        if self.global_rank == 0:
+            self.metrics_file.close()
         dist.destroy_process_group()

--- a/src/deep_taxon/nn/no_lightning.py
+++ b/src/deep_taxon/nn/no_lightning.py
@@ -1,0 +1,119 @@
+import os
+import shutil
+
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch.distributed as dist
+
+from tqdm import tqdm
+
+class Trainer:
+    def __init__(self, model, targs, data_mod, output_dir):
+
+        self.local_rank = targs['local_rank']
+        self.global_rank = targs['global_rank']
+        self.world_size = targs['world_size']
+        self.model = model.to(self.local_rank)
+        self.loss = model._loss
+        self.data_mod = data_mod
+        self.train_data = None     # This is a datalaoder
+        self.validate_data = None  # This is a datalaoder
+        self.optimizer = model.configure_optimizers()
+        self.scheduler = None
+        if isinstance(self.optimizer, tuple):
+            self.scheduler = self.optimizer[1][0]
+            self.optimizer = self.optimizer[0][0]
+        self.epochs_run = 0
+        self.snapshot_path = f"{output_dir}/last.ckpt"
+
+        self.best_path = None
+        self.best_loss = float('inf')
+        self.output_dir = output_dir
+
+        if os.path.exists(self.snapshot_path):
+            print(f"Loading snapshot from {self.snapshot_path}")
+            self._load_snapshot(snapshot_path)
+
+
+    def _load_snapshot(self, snapshot_path):
+        snapshot = torch.load(snapshot_path)
+        self.model.load_state_dict(snapshot["MODEL_STATE"])
+        self.best_loss = snapshot["LOSS"]
+        self.epochs_run = snapshot["EPOCHS_RUN"]
+        self.optimizer = snapshot["OPTIMIZER"]
+        self.scheduler = snapshot.get("SCHEDULER", None)
+        print(f"Resuming training from snapshot at Epoch {self.epochs_run}")
+
+    def _run_batch(self, source, targets):
+        if torch.is_grad_enabled():
+            self.optimizer.zero_grad()
+        output = self.model(source)
+        loss = self.loss(output, targets.long())
+        if torch.is_grad_enabled():
+            loss.backward()
+            self.optimizer.step()
+        return loss
+
+    @torch.enable_grad()
+    def _run_train(self, epoch):
+        if self.train_data is None:
+            self.train_data = self.data_mod.train_dataloader()
+        b_sz = len(next(iter(self.train_data))[0])
+        print(f"[GPU{self.global_rank}] Epoch {epoch} | Batchsize: {b_sz} | Steps: {len(self.train_data)}")
+        it = self.train_data
+        if self.global_rank == 0:
+            it = tqdm(it, desc=f"Epoch {epoch}", leave=False)
+        for source, targets in it:
+            source = source.to(self.local_rank)
+            targets = targets.to(self.local_rank)
+            self._run_batch(source, targets)
+        if self.scheduler is not None:
+            self.scheduler.step()
+
+        return None
+
+    @torch.no_grad()
+    def _run_validate(self, epoch):
+        if self.validate_data is None:
+            self.validate_data = self.data_mod.validate_dataloader()
+        it = self.validate_data
+        if self.global_rank == 0:
+            it = tqdm(it, desc=f"Validation epoch {epoch}", leave=False)
+        for source, targets in it:
+            source = source.to(self.local_rank)
+            targets = targets.to(self.local_rank)
+            self._run_batch(source, targets)
+        return None
+
+    def _save_snapshot(self, epoch, valid_loss):
+        snapshot = {
+            "MODEL_STATE": self.model.module.state_dict(),
+            "EPOCHS_RUN": epoch,
+            "OPTIMIZER": self.optimizer,
+            "LOSS": valid_loss,
+        }
+        if self.scheduler is not None:
+            snapshot['SCHEDULER'] = self.scheduler
+        torch.save(snapshot, self.snapshot_path)
+
+        # save best checkpoint
+        if valid_loss < self.best_loss:
+            self.best_loss = valid_loss
+            to_rm = self.best_path
+            self.best_path = f"{self.output_dir}/best_epoch{epoch:03}.ckpt"
+            shutil.copyfile(self.snapshot_path, self.best_path)
+            if to_rm is not None:
+                os.remove(to_rm)
+        print(f"Epoch {epoch} | Training snapshot saved at {self.snapshot_path}")
+
+    def train(self, max_epochs: int):
+        dist.init_process_group(backend="nccl", rank=self.global_rank, world_size=self.world_size)
+        self.model = DDP(self.model, device_ids=[self.local_rank])
+        for epoch in range(self.epochs_run, max_epochs):
+            self._run_train(epoch)
+            valid_loss = self._run_validate()
+            if self.local_rank == 0:
+                self._save_snapshot(epoch, valid_loss)
+            dist.barrier()
+        self.model = self.model.model
+        dist.destroy_process_group()

--- a/src/deep_taxon/nn/train.py
+++ b/src/deep_taxon/nn/train.py
@@ -14,13 +14,14 @@ from .utils import process_gpus, process_model, process_output
 from .loader import add_dataset_arguments, DeepIndexDataModule
 from ..sequence import DeepIndexFile
 from . import TIME_OFFSET
+from .no_lightning import Trainer
 from hdmf.utils import docval
 from hdmf.common import get_hdf5io
 
 import argparse
 import logging
 
-from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning import Trainer as PLTrainer, seed_everything
 from pytorch_lightning.loggers import CSVLogger
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, StochasticWeightAveraging, LearningRateMonitor, DeviceStatsMonitor, TQDMProgressBar
 
@@ -30,7 +31,6 @@ from pytorch_lightning.plugins.environments import SLURMEnvironment, LSFEnvironm
 from pytorch_lightning.strategies import DDPStrategy
 
 import torch
-
 try:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -145,6 +145,7 @@ def parse_args(*addl_args, argv=None):
     parser.add_argument('--swa', action='store_true', default=False, help='use stochastic weight averaging')
     parser.add_argument('--csv', action='store_true', default=False, help='log to a CSV file instead of WandB')
     parser.add_argument('-e', '--epochs', type=int, help='number of epochs to use', default=1)
+    parser.add_argument('--pytorch', action='store_true', default=False, help='do not use PyTorch Lightning')
     grp = parser.add_mutually_exclusive_group()
     grp.add_argument('-i', '--init', type=str, help='a checkpoint to initalize a model from', default=None)
     grp.add_argument('-c', '--checkpoint', type=str, help='resume training from file', default=None)
@@ -236,6 +237,12 @@ def process_args(args=None):
                 RANK = 0
                 SIZE = 1
             print(f'global rank {env.global_rank()} of {env.world_size()} - local rank {env.local_rank()} on node {env.node_rank()} - {torch.cuda.device_count()} GPUs visible', file=sys.stderr)
+            if args.pytorch:
+                env.main_address
+                env.main_port
+                targs['local_rank'] = env.local_rank()
+                targs['global_rank'] = env.global_rank()
+                targs['world_size'] = env.world_size()
         else:
             os.environ["MASTER_ADDR"] = "127.0.0.1"
             os.environ["MASTER_PORT"] = "12910"
@@ -420,6 +427,7 @@ def run_lightning(argv=None):
     import os
     import pprint
 
+
     pformat = pprint.PrettyPrinter(sort_dicts=False, width=100, indent=2).pformat
 
     model, args, addl_targs, data_mod = process_args(parse_args(argv=argv))
@@ -523,8 +531,6 @@ def run_lightning(argv=None):
         print0('DataLoader args\n:', pformat(data_mod._loader_kwargs), file=sys.stderr)
         print0('Model:\n', model, file=sys.stderr)
 
-    trainer = Trainer(**targs)
-
     if args.debug:
         #print_dataloader(data_mod.test_dataloader())
         print_dataloader(data_mod.train_dataloader())
@@ -535,7 +541,14 @@ def run_lightning(argv=None):
     logger.log_metrics({'start_time': t - TIME_OFFSET})
     print0('START_TIME', t)
     print0('LOGGER TIME OFFSET', TIME_OFFSET)
-    trainer.fit(model, data_mod, ckpt_path=args.checkpoint)
+
+    if args.pytorch:
+        trainer = Trainer(model, targs, data_mod, outdir)
+        trainer.train(args.epochs)
+    else:
+        trainer = PLTrainer(**targs)
+        trainer.fit(model, data_mod, ckpt_path=args.checkpoint)
+
     e = datetime.now()
     td = e - s
     hours, seconds = divmod(td.seconds, 3600)
@@ -564,7 +577,7 @@ def lightning_lr_find(argv=None):
 
     targs = addl_targs
 
-    trainer = Trainer(**targs)
+    trainer = TPLrainer(**targs)
 
     s = datetime.now()
     lr_finder = trainer.lr_find(model)

--- a/src/deep_taxon/run/run_job.py
+++ b/src/deep_taxon/run/run_job.py
@@ -22,6 +22,7 @@ def run_train(argv=None):
     parser.add_argument('-m', '--message',     help="message to write to log file", default=None)
     parser.add_argument('-L', '--log',         help="the log file to store run information in", default='jobs.log')
     parser.add_argument('--submit',            help="submit job to queue", action='store_true', default=False)
+    parser.add_argument('--pytorch',           help="use Pytorch only", action='store_true', default=False)
     prof_grp = parser.add_mutually_exclusive_group()
     prof_grp.add_argument('--profile', action='store_true', default=False, help='profile with PyTorch Lightning profile')
     prof_grp.add_argument('--cuda_profile', action='store_true', default=False, help='profile with PyTorch CUDA profiling')
@@ -108,6 +109,9 @@ def run_train(argv=None):
         options += ' -s'
         if isinstance(args.sanity, str):
             options += f' {args.sanity}'
+
+    if args.pytorch:
+        options += f' --pytorch'
 
     if args.early_stop:
         options += f' --early_stop'


### PR DESCRIPTION
Add non-Lightning implementation of training. This can be enabled with the `--pytorch` flag.

```
$ deep-taxon train <CONFIG> <INPUT> <OUTDIR> --pytorch [options]
```

The usage is the same for `train-job`

```
$ deep-taxon train-job <CONFIG> <INPUT> <OUTDIR> <TMP_SHELL_SCRIPT> --pytorch [options]
```
