### PR TITLE
Update distance based loss code

### DIFF
--- a/configs/distance_loss.yml
+++ b/configs/distance_loss.yml
@@ -1,10 +1,10 @@
 # This config file is for running with a distance-based loss.
 seed: 1111
 
-model: wide_resnet101_2
+model: convnext_small
 simple_clf: true
 bottleneck: false
-n_outputs: 128
+n_outputs: 64
 
 # sequence windows
 window: 1024
@@ -14,7 +14,7 @@ step: 128
 classify: false
 manifold: true
 condensed: true
-hyperbolic: true
+hyperbolic: false
 tgt_tax_lvl: species
 
 # optimizer configurations
@@ -22,7 +22,7 @@ optimizer: adamw
 lr: 0.01
 
 accumulate: 1
-batch_size: 256
+batch_size: 768
 
 # scheduler configurations
 lr_scheduler: step

--- a/configs/distance_loss.yml
+++ b/configs/distance_loss.yml
@@ -1,0 +1,35 @@
+# This config file is for running with a distance-based loss.
+seed: 1111
+
+model: wide_resnet101_2
+simple_clf: true
+bottleneck: false
+n_outputs: 128
+
+# sequence windows
+window: 1024
+step: 128
+
+# loss function configurations
+classify: false
+manifold: true
+condensed: true
+hyperbolic: true
+tgt_tax_lvl: species
+
+# optimizer configurations
+optimizer: adamw
+lr: 0.01
+
+accumulate: 1
+batch_size: 256
+
+# scheduler configurations
+lr_scheduler: step
+step_size: 3          # 07/25/22 - I changed this from 5 to 3. I think 5 might be unnecessarily long
+n_steps: 2
+step_factor: 0.1
+
+# stochastic weight averaging configurations
+swa_start: 15
+swa_anneal: 1          # 12/22/2021 - I have no reason to believe this is the optimal value, just setting to what I think has been used previously

--- a/env/env.sh
+++ b/env/env.sh
@@ -1,3 +1,8 @@
 ENV_NAME=${1:?Please specify an environment name}
-conda create --yes -n $ENV_NAME pytorch torchvision torchaudio cudatoolkit=11.3 torchtext -c pytorch
-conda run -n $ENV_NAME pip install --no-cache-dir hdmf==3.2.1 pytorch_lightning==1.6.3 scikit-bio==0.5.7 wandb==0.12.16 torch_optimizer==0.3.0
+conda create --yes -n $ENV_NAME pytorch torchvision torchaudio cudatoolkit=11.6 torchtext -c pytorch -c conda-forge
+if [ $? -ne 0 ]; then echo "Failed to create environment $ENV_NAME"; exit 1; fi
+conda activate $ENV_NAME
+MPICC="cc -target-accel=nvidia80 -shared" pip install --force-reinstall --no-cache-dir --no-binary=mpi4py mpi4py
+module load cray-hdf5-parallel
+HDF5_MPI=ON CC=cc pip install -v --force-reinstall --no-cache-dir --no-binary=h5py --no-build-isolation --no-deps h5py
+pip install --no-cache-dir -r requirements.txt

--- a/src/deep_taxon/nn/loader.py
+++ b/src/deep_taxon/nn/loader.py
@@ -907,7 +907,7 @@ class DeepIndexDataModule(pl.LightningDataModule):
     def val_dataloader(self):
         kwargs = self._loader_kwargs.copy()
         if self._val_sampler is None:
-            # set up the validation sampler - DO NOT shuffle for training
+            # set up the validation sampler - DO NOT shuffle for validation
             val_len = self.get_min(self.dataset.get_subset_len(validate=True), self.batch_size)
             s_kwargs = dict(n_partitions=self.n_partitions, part_smplr_rng=self.seed+self.rank)
             if self.sanity:

--- a/src/deep_taxon/nn/loss.py
+++ b/src/deep_taxon/nn/loss.py
@@ -5,95 +5,93 @@ from torch.nn import Parameter
 import math
 
 
+class CondensedDistanceLoss(nn.Module):
+
+    def __init__(self, dmat, batch_size):
+        super().__init__()
+        self.dmat = dmat
+        if not isinstance(self.dmat, torch.Tensor):
+            raise ValueError(f"CondensedDistanceLoss requires a Tensor, got {type(self.dmat)}")
+        self.dmat /= self.dmat.max()
+
+        self.device = dmat.device
+        self.m = torch.tensor(int((1 + math.sqrt(1 + 8*len(dmat))) / 2), device=self.device)
+        self.indices = torch.triu_indices(batch_size, batch_size, offset=1, device=self.device)
+        self.batch_size = batch_size
+        self.zero = torch.tensor(0.0, device=self.device, dtype=torch.float32)
+
+    def compute_distances(self, output):
+        raise NotImplemented
+
+    def forward(self, output, target_cls):
+        """
+        Computes the phylogenetic distance loss
+
+        Parameters
+        ----------
+        output
+            the output of a network
+
+        target
+            the square root of the patristic distances
+        """
+        indices = self.indices
+        if len(target_cls) != self.batch_size:
+            self.indices = torch.triu_indices(len(target_cls), len(target_cls), offset=1, device=self.device)
+
+        # get sub-distance matrix from condensed distance matrix
+        i, j = torch.sort(target_cls[indices], dim=0)[0]
+        target = self.m * i + j - torch.div(((i + 2) * (i + 1)), 2, rounding_mode='trunc')
+        target = self.dmat[target]
+        target[i == j] = self.zero
+
+        # compute distances and subset it to get condensed form
+        dist = self.compute_distances(output)
+        dist = dist[indices[0], indices[1]]
+
+        loss = (dist - target).abs().mean()
+        return loss
+
+
+def euclidean_loss(output):
+    x2 = output.pow(2).sum(axis=1)
+    xy = 2*output.mm(output.T)
+    dist = (((x2 - xy).T + x2))
+    return dist
+
+
+def hyperbolic_loss(output, tol=1e-6):
+    # compute hyperbolic distance
+    output = output.double()
+    s = torch.sqrt(1 + torch.sum(output ** 2, dim=1))
+    B = torch.outer(s, s)
+    B -= output.matmul(output.T)
+    B[(B - 1.0).abs() < tol] = 1.0
+    dist = torch.acosh(B)
+    return dist
+
+
+class CondensedEuclideanMAELoss(CondensedDistanceLoss):
+
+    def compute_distances(self, output):
+        return euclidean_loss(output)
+
+
+class CondensedHyperbolicMAELoss(CondensedDistanceLoss):
+
+    def __init__(self, dmat, batch_size, tol=1e-6):
+        super().__init__(dmat, batch_size)
+        self.tol = torch.tensor(tol, device=self.device)
+
+    def compute_distances(self, output):
+        return hyperbolic_loss(output, tol=self.tol)
+
+
 class EuclideanMAELoss(nn.Module):
 
-    def __init__(self):
-        super().__init__()
-
     def forward(self, output, target):
-        """
-        Computes the phylogenetic distance loss
-
-        Parameters
-        ----------
-        output
-            the output of a network
-
-        target
-            the square root of the patristic distances
-        """
-        x2 = output.pow(2).sum(axis=1)
-        xy = 2*output.mm(output.T)
-        dist = (((x2 - xy).T + x2))
-        n = output.shape[0]
-        loss = (dist - target).abs().tril(diagonal=-1).sum()/(n*(n-1))
-        return loss
-
-
-class DistMSELoss(nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, output, target):
-        """
-        Computes the phylogenetic distance loss
-
-        Parameters
-        ----------
-        output
-            the output of a network
-
-        target
-            the square root of the patristic distances
-        """
-        x2 = output.pow(2).sum(axis=1)
-        xy = 2*output.mm(output.T)
-        dist = (((x2 - xy).T + x2))
-        n = output.shape[0]
-        loss = (dist - target).pow(2).sum()/(n*(n-1))
-        #loss = ((dist - target)/target.exp()).pow(2).sum()/(n*(n-1))
-        return loss
-
-
-# class HyperbolicDistortionLoss(nn.Module):
-#
-#     def __init__(self, tol=1e-6, k=5):
-#         super().__init__()
-#         self.tol = tol
-#         self.k = k
-#         self._mean = torch.tensor((k+1)/2)
-#
-#         self._var = torch.tensor((k + 1) * (2 * k + 1) / 6) - self._mean**2
-#
-#     def forward(self, output, target):
-#         """
-#         Computes the phylogenetic distance loss
-#
-#         Parameters
-#         ----------
-#         output
-#             the output of a network
-#
-#         target
-#             the square root of the patristic distances
-#         """
-#
-#         output = output.double()    # might not need this, since we just need it for kNN
-#         # compute hyperbolic distance
-#         s = torch.sqrt(1 + torch.sum(output ** 2, dim=1))
-#         B = torch.outer(s, s)
-#         B -= output.matmul(output.T)
-#         B[(B - 1.0).abs() < self.tol] = 1.0
-#         dist = torch.acosh(B)
-#
-#         # dev_o = dist.topk(self.k + 1, largest=False).indices[:, 1:] - self._mean
-#         # dev_t = target.topk(self.k + 1, largest=False).indices[:, 1:] - self._mean
-#         # pearson = ((dev_o * dev_t).sum()/self.k)/self._var
-#         # loss = pearson
-#
-#         loss = ((dist.topk(output.shape[0], largest=False).indices[:, 1:] - target.topk(output.shape[0], largest=False).indices[:, 1:])**2).float().mean()
-#         return loss
+        dist = euclidean_loss(output)
+        return (dist - target).abs().mean()
 
 
 class HyperbolicMAELoss(nn.Module):
@@ -103,30 +101,8 @@ class HyperbolicMAELoss(nn.Module):
         self.tol = tol
 
     def forward(self, output, target):
-        """
-        Computes the phylogenetic distance loss
-
-        Parameters
-        ----------
-        output
-            the output of a network
-
-        target
-            the square root of the patristic distances
-        """
-        # compute hyperbolic distance
-        output = output.double()
-        s = torch.sqrt(1 + torch.sum(output ** 2, dim=1))
-        B = torch.outer(s, s)
-        B -= output.matmul(output.T)
-        B[(B - 1.0).abs() < self.tol] = 1.0
-        dist = torch.acosh(B)
-
-        # compute mean absolute error
-        n = output.shape[0]
-        loss = (dist - target).abs().tril(diagonal=-1).sum()/(n*(n-1))
-        return loss
-
+        dist = hyperbolic_loss(output, tol=self.tol)
+        return (dist - target).abs().mean()
 
 
 class ArcMarginProduct(nn.Module):

--- a/src/deep_taxon/nn/models/convnext.py
+++ b/src/deep_taxon/nn/models/convnext.py
@@ -233,7 +233,7 @@ class ConvNeXtTiny(ConvNeXt):
     def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(96, 192, 384, 768, l3=9)
         hparams.stochastic_depth_prob = 0.1
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('convnext_small')
@@ -241,7 +241,7 @@ class ConvNeXtSmall(ConvNeXt):
     def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(96, 192, 384, 768)
         hparams.stochastic_depth_prob = 0.4
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('convnext_base')
@@ -249,12 +249,12 @@ class ConvNeXtBase(ConvNeXt):
     def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(128, 256, 512, 1024)
         hparams.stochastic_depth_prob = 0.5
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('convnext_large')
-class ConvNeXtLarge(ConvNeXt, **kwargs):
-    def __init__(self, hparams):
+class ConvNeXtLarge(ConvNeXt):
+    def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(192, 384, 768, 1536)
         hparams.stochastic_depth_prob = 0.5
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)

--- a/src/deep_taxon/nn/models/convnext.py
+++ b/src/deep_taxon/nn/models/convnext.py
@@ -138,9 +138,10 @@ class CNBlockConfig:
 class ConvNeXt(AbstractLit):
     def __init__(
         self,
-        hparams: Namespace
+        hparams: Namespace,
+        **kwargs
     ) -> None:
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
         stochastic_depth_prob = getattr(hparams, 'stochastic_depth_prob ', 0.0)
         layer_scale = getattr(hparams, 'layer_scale', 1e-6)
@@ -229,7 +230,7 @@ def _block_setting(in1, in2, in3, in4, l1=3, l2=3, l3=27, l4=3):
 
 @model('convnext_tiny')
 class ConvNeXtTiny(ConvNeXt):
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(96, 192, 384, 768, l3=9)
         hparams.stochastic_depth_prob = 0.1
         super().__init__(hparams)
@@ -237,7 +238,7 @@ class ConvNeXtTiny(ConvNeXt):
 
 @model('convnext_small')
 class ConvNeXtSmall(ConvNeXt):
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(96, 192, 384, 768)
         hparams.stochastic_depth_prob = 0.4
         super().__init__(hparams)
@@ -245,14 +246,14 @@ class ConvNeXtSmall(ConvNeXt):
 
 @model('convnext_base')
 class ConvNeXtBase(ConvNeXt):
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams.block_setting = _block_setting(128, 256, 512, 1024)
         hparams.stochastic_depth_prob = 0.5
         super().__init__(hparams)
 
 
 @model('convnext_large')
-class ConvNeXtLarge(ConvNeXt):
+class ConvNeXtLarge(ConvNeXt, **kwargs):
     def __init__(self, hparams):
         hparams.block_setting = _block_setting(192, 384, 768, 1536)
         hparams.stochastic_depth_prob = 0.5

--- a/src/deep_taxon/nn/models/lit.py
+++ b/src/deep_taxon/nn/models/lit.py
@@ -172,7 +172,7 @@ class AbstractLit(LightningModule):
             self.log(self.train_acc, self.accuracy(output, target), prog_bar=True)
         stats = self.time_stats(batch_idx)
         stats[self.train_loss] = loss
-        self.log_dict(stats)
+        self.log_dict(stats, sync_dist=True)
         return loss
 
     def training_epoch_end(self, outputs):
@@ -191,7 +191,7 @@ class AbstractLit(LightningModule):
             self.log(self.val_acc, self.accuracy(output, target), prog_bar=True)
         stats = self.time_stats(batch_idx)
         stats[self.val_loss] = loss
-        self.log_dict(stats)
+        self.log_dict(stats, sync_dist=True)
         return loss
 
     def validation_epoch_end(self, outputs):

--- a/src/deep_taxon/nn/models/resnet.py
+++ b/src/deep_taxon/nn/models/resnet.py
@@ -433,6 +433,18 @@ class ResNeXt101_32x8d(ResNet):
         super().__init__(hparams, **kwargs)
 
 
+@model('resnext101_64x4d')
+class ResNeXt101_64x4d(ResNet):
+
+    def __init__(self, hparams, **kwargs):
+        hparams = self.check_hparams(hparams)
+        hparams.block = Bottleneck
+        hparams.layers = [3, 4, 23, 3]
+        hparams.groups = 64
+        hparams.width_per_group = 4
+        super().__init__(hparams, **kwargs)
+
+
 @model('wide_resnet50_2')
 class Wide_ResNet50_2(ResNet):
 

--- a/src/deep_taxon/nn/models/resnet.py
+++ b/src/deep_taxon/nn/models/resnet.py
@@ -128,7 +128,7 @@ class FeatureReduction(nn.Module):
 
 class ResNet(AbstractLit):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         if not hasattr(hparams, 'zero_init_residual'):
             hparams.zero_init_residual = False
         if not hasattr(hparams, 'groups'):
@@ -146,7 +146,7 @@ class ResNet(AbstractLit):
         if not hasattr(hparams, 'dropout_clf'):
             hparams.dropout_clf = False
 
-        super(ResNet, self).__init__(hparams)
+        super(ResNet, self).__init__(hparams, **kwargs)
 
         replace_stride_with_dilation = hparams.replace_stride_with_dilation
         block = hparams.block
@@ -333,126 +333,126 @@ class ResNet(AbstractLit):
 @model('resnet9')
 class ResNet9(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = BasicBlock
         hparams.layers = [1, 1, 1, 1]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet18')
 class ResNet18(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = BasicBlock
         hparams.layers = [2, 2, 2, 2]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 @model('resnet26')
 class ResNet26(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [2, 2, 2, 2]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet34')
 class ResNet34(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = BasicBlock
         hparams.layers = [3, 4, 6, 3]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet50')
 class ResNet50(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 6, 3]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet74')
 class ResNet74(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 14, 3]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet101')
 class ResNet101(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 23, 3]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnet152')
 class ResNet152(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 8, 36, 3]
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnext50_32x4d')
 class ResNeXt50_32x4d(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 6, 3]
         hparams.groups = 32
         hparams.width_per_group = 4
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('resnext101_32x8d')
 class ResNeXt101_32x8d(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 23, 3]
         hparams.groups = 32
         hparams.width_per_group = 8
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('wide_resnet50_2')
 class Wide_ResNet50_2(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 6, 3]
         hparams.width_per_group = 128
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 @model('wide_resnet101_2')
 class Wide_ResNet101_2(ResNet):
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, **kwargs):
         hparams = self.check_hparams(hparams)
         hparams.block = Bottleneck
         hparams.layers = [3, 4, 23, 3]
         hparams.width_per_group = 128
-        super().__init__(hparams)
+        super().__init__(hparams, **kwargs)
 
 
 class ResNetFeatures(nn.Module):

--- a/src/deep_taxon/nn/utils.py
+++ b/src/deep_taxon/nn/utils.py
@@ -50,7 +50,7 @@ def _check_hparams(args):
     del args.hparams
 
 
-def process_model(args, inference=False, taxa_table=None):
+def process_model(args, inference=False, taxa_table=None, distances=None):
     """
     Process a model argument
 
@@ -88,7 +88,7 @@ def process_model(args, inference=False, taxa_table=None):
             else:
                 raise e
     elif getattr(args, 'checkpoint', None) is not None:
-        model = model_cls.load_from_checkpoint(args.checkpoint, strict=False)
+        model = model_cls.load_from_checkpoint(args.checkpoint, strict=False, distances=distances)
     else:
         if not hasattr(args, 'classify'):
             raise ValueError('Parser must check for classify/regression/manifold '
@@ -102,7 +102,7 @@ def process_model(args, inference=False, taxa_table=None):
                 n_taxa_all[key] = len(taxa_table[key].elements)
             n_taxa_all['species'] = len(taxa_table['species'])
             args.n_taxa_all = n_taxa_all
-        model = model_cls(args)
+        model = model_cls(args, distances=distances)
 
     return model
 

--- a/src/deep_taxon/sequence/dna_table.py
+++ b/src/deep_taxon/sequence/dna_table.py
@@ -698,11 +698,14 @@ class LazyWindowChunkedDIFile:
         self.id = np.asarray(difile.seq_table['id'].data, dtype=int)
         log('setting labels', print_msg=rank==0)
         self.labels = np.asarray(difile._labels)
+        self.labels = torch.from_numpy(self.labels)
+
         log('setting seq_index', print_msg=rank==0)
         self.seq_index = np.asarray(difile.seq_table['sequence_index'].data, dtype=int)
         log('setting sequence', print_msg=rank==0)
         if load:
             self.sequence = np.asarray(difile.seq_table['sequence_index'].target.data, dtype=np.uint8)
+            self.sequence = torch.from_numpy(self.sequence)
         else:
             self.sequence = difile.seq_table['sequence_index'].target.data
         log('done setting important data', print_msg=rank==0)
@@ -861,7 +864,7 @@ class LazyWindowChunkedDIFile:
         item['seq_idx'] = item['id']
 
         if rev:
-            item['seq'] = self.rcmap[item['seq'][l-e:l-s].astype(int)].flip(0)
+            item['seq'] = self.rcmap[item['seq'][l-e:l-s].long()].flip(0)
         else:
             item['seq'] = item['seq'][s:e]
         item['id'] = i

--- a/src/deep_taxon/sequence/dna_table.py
+++ b/src/deep_taxon/sequence/dna_table.py
@@ -9,8 +9,9 @@ import numpy as np
 from tqdm import tqdm
 import torch
 import torch.nn.functional as F
+import torch.multiprocessing as mp
+import ctypes
 import sklearn.neighbors as skn
-from scipy.spatial.distance import squareform
 
 from hdmf.common import VectorIndex, VectorData, DynamicTable, CSRMatrix,\
                         DynamicTableRegion, register_class, EnumData
@@ -481,7 +482,7 @@ class DeepIndexFile(Container):
         self.__indices = indices
         self._labels = self._labels[self.__indices]
 
-    def load(self, sequence=False, device=None, verbose=True):
+    def load(self, sequence=False, device=None, verbose=True, shmem=True):
         indices = self.__indices
         self.__loaded = True
         if self.__indices is not None:
@@ -528,14 +529,18 @@ class DeepIndexFile(Container):
                 self.seq_table['sequence_index'].target.transform(lambda x: sequence_subset)
             log('Loading data subset - done loading data subset', print_msg=verbose)
         else:
-            _load = lambda x: x[:]
+            _load = lambda x: x.astype(int)[:]
             log('Loading data - loading IDs', print_msg=verbose)
             self.seq_table['id'].transform(_load)
             log('Loading data - loading sequence lengths', print_msg=verbose)
-            self.seq_table['length'].transform(lambda x: x.astype(int)[:])
+            self.seq_table['length'].transform(_load)
             log('Loading data - loading sequence index', print_msg=verbose)
             self.seq_table['sequence_index'].transform(_load)
             if sequence:
+                if shmem:
+                    _load = lambda x: np.ctypeslib.as_array(mp.Array(ctypes.c_uint8, x, lock=False).get_obj())
+                else:
+                    _load = lambda x: x[:]
                 log('Loading data - loading sequences', print_msg=verbose)
                 self.seq_table['sequence_index'].target.transform(_load)
             log('Loading data - done loading data', print_msg=verbose)
@@ -693,36 +698,24 @@ class LazyWindowChunkedDIFile:
             difile.set_sequence_subset(indices)
         difile.load(sequence=load, verbose=rank==0)
         log('setting lengths', print_msg=rank==0)
-        self.lengths = np.asarray(difile.seq_table['length'].data, dtype=int)
+        self.lengths = difile.seq_table['length'].data
         log('setting ids', print_msg=rank==0)
-        self.id = np.asarray(difile.seq_table['id'].data, dtype=int)
+        self.id = difile.seq_table['id'].data
         log('setting labels', print_msg=rank==0)
-        self.labels = np.asarray(difile._labels)
-        self.labels = torch.from_numpy(self.labels)
+        self.labels = torch.from_numpy(difile._labels)  # store as torch Tensor since this is used for loss calculations
 
         log('setting seq_index', print_msg=rank==0)
-        self.seq_index = np.asarray(difile.seq_table['sequence_index'].data, dtype=int)
+        self.seq_index = difile.seq_table['sequence_index'].data
         log('setting sequence', print_msg=rank==0)
         if load:
-            self.sequence = np.asarray(difile.seq_table['sequence_index'].target.data, dtype=np.uint8)
-            self.sequence = torch.from_numpy(self.sequence)
+            self.sequence = torch.from_numpy(difile.seq_table['sequence_index'].target.data)
         else:
             self.sequence = difile.seq_table['sequence_index'].target.data
         log('done setting important data', print_msg=rank==0)
 
         self.n_classes = difile.n_classes
-        self.classes = difile.get_label_classes()
         self.vocab = difile.get_vocab()
 
-
-        self.distances = None
-        square = False
-        if distances:
-            cond = difile.distances.data.ndim == 1
-            if (not cond and not square) or (cond and square):
-                self.distances = squareform(difile.distances.data)
-            else:
-                self.distances = difile.distances.data[:]
         self.node_ids = None
         self.tree_graph = None
         if tree_graph:

--- a/src/deep_taxon/utils.py
+++ b/src/deep_taxon/utils.py
@@ -10,6 +10,11 @@ import warnings
 import numpy as np
 
 
+
+def log(msg, print_msg=True):
+    if print_msg:
+        print(f'{datetime.now()} - {msg}', file=sys.stderr)
+
 @contextmanager
 def ccm(cond, cm):
     """


### PR DESCRIPTION
 This PR updates the distanced based loss to work with current state of code. 

- Running this type of training requires a training data file with a distance matrix
  - small test dataset: `$CFS/m3513/endurable/gtdb/test_r207.rep.dist.h5`
  - full dataset: `$CFS/m3513/endurable/gtdb/r207.rep.dist.h5`
- Data preparation code was modified to reduce storage of distance matrix by writing a condensed form with 32-bit precision 
- Code was reworked to allow for two ways of running distance loss calculation. Both ways calculate the full distance matrix between all samples in a batch. This is more efficient than subsetting batches, presumably because it results in a subsetting operation that replicates batch samples. 
  1. `condensed: true` - the final loss subsets the distance matrix before computing deviation from target distances
  2. `condensed: false` - the final loss is calculated using the full distance matrix without subsetting before computing deviation from target distances
- A configuration file was provided in the `config` directory for an example on how to use this functionality
- By default, loss function classes convert distance to a similarity measure with the formula `S = 1 / (1 + D/2)`, where `S` is similarity and `D` is distance. The loss is calculated as the mean percent deviation: `|P - T| / T` where `T` is true similarity and `P` is predicted similarity

In addition to distance loss updates, this PR adds the use of `multiprocessing.Array` for storing sequence data. This prevents DataLoader workers from replicating sequence data, making it possible to use more workers