### PR TITLE
Add bin classification

### DIFF
--- a/scripts/tax_acc_sourmash.py
+++ b/scripts/tax_acc_sourmash.py
@@ -3,7 +3,7 @@ import pandas as pd
 import re
 from sklearn.metrics import accuracy_score, precision_score, recall_score
 
-from exabiome.utils import parse_logger
+from deep_taxon.utils import parse_logger
 
 parser = argparse.ArgumentParser()
 parser.add_argument('lca', type=str, help='sourmash LCA output')
@@ -37,7 +37,7 @@ def func(row):
 
 logger.info(f'reading GTDB metadata file from {args.metadata}')
 keep_cols = ['accession', 'gtdb_taxonomy', 'gtdb_genome_representative']
-taxdf = pd.read_csv(args.metadata, header=0, sep='\t')[keep_cols].apply(func, axis=1).set_index('accession')
+taxdf = pd.read_csv(args.metadata, header=0, sep='\t', usecols=keep_cols).apply(func, axis=1).set_index('accession')
 
 
 # "GCA_000380905.1-1094-AQYW01000001.1 Nanoarchaeota archaeon SCGC AAA011-L22 DUSEL4_1DRAFT_contig_80.81_C, whole genome shotgun sequence",nomatch,,,,,,,,

--- a/src/deep_taxon/__init__.py
+++ b/src/deep_taxon/__init__.py
@@ -19,6 +19,7 @@ def main():
             'ncbi-path': Command('gtdb.download.ncbi_path', 'Print path at NCBI FTP site to stdout'),
             'ncbi-fetch': Command('gtdb.download.ncbi_fetch', 'Retrieve sequence data from NCBI FTP site using rsync'),
             'make-fof': Command('gtdb.make_fof.make_fof', 'Find files and print paths for accessions'),
+            'get-accessions': Command('gtdb.make_fof.get_accessions', 'Print accessions from metadata file'),
             'prepare-data': Command('gtdb.prepare_data.prepare_data', 'Aggregate sequence data GTDB using a file-of-files'),
             'merge-meta': Command('gtdb.prepare_data.merge_metadata', 'Merge metadata files from different sources'),
             'count-sequence': Command('gtdb.prepare_data.count_sequence', 'Count the length of total sequence length for a set of accessions'),

--- a/src/deep_taxon/__init__.py
+++ b/src/deep_taxon/__init__.py
@@ -20,6 +20,8 @@ def main():
             'ncbi-fetch': Command('gtdb.download.ncbi_fetch', 'Retrieve sequence data from NCBI FTP site using rsync'),
             'make-fof': Command('gtdb.make_fof.make_fof', 'Find files and print paths for accessions'),
             'get-accessions': Command('gtdb.make_fof.get_accessions', 'Print accessions from metadata file'),
+            'split-fof': Command('gtdb.make_fof.split_fof', 'Split file-of-files into roughly equal sized file of files'),
+            'append-accessions': Command('gtdb.make_fof.append_accessions', 'Append accessions to Fasta headers'),
             'prepare-data': Command('gtdb.prepare_data.prepare_data', 'Aggregate sequence data GTDB using a file-of-files'),
             'merge-meta': Command('gtdb.prepare_data.merge_metadata', 'Merge metadata files from different sources'),
             'count-sequence': Command('gtdb.prepare_data.count_sequence', 'Count the length of total sequence length for a set of accessions'),

--- a/src/deep_taxon/gtdb/download.py
+++ b/src/deep_taxon/gtdb/download.py
@@ -83,7 +83,7 @@ def get_accessions(args):
             accessions = [tip.name[3:].replace(' ', '_') for tip in root.tips()]
         elif args.metadata:
             accessions = pd.read_csv(args.accession, header=0, sep='\t').accession
-            accessions = [acc[3:] for acc in accessions]
+            accessions = accessions.str[3:]
         else:
             accessions = [args.accession]
     return accessions
@@ -102,7 +102,7 @@ def ncbi_fetch(args):
     grp = parser.add_mutually_exclusive_group()
     grp.add_argument('-f', '--file', action='store_true', default=False, help='accession is a file with a list of accessions, one per line')
     grp.add_argument('-t', '--tree', action='store_true', default=False, help='accessions is a tree file with accessions')
-    grp.add_argument('-m', '--metadata', action='store_true', default=False, help='accession is a file with a list of accessions, one per line')
+    grp.add_argument('-m', '--metadata', action='store_true', default=False, help='accessions is a metdata file from GTDB')
 
     parser.add_argument('-p', '--processes', type=int, help='the number of rsync subprocesses to run', default=1)
     parser.add_argument('-q', '--quiet', action='store_true', default=False, help='print less information to log file')

--- a/src/deep_taxon/gtdb/make_fof.py
+++ b/src/deep_taxon/gtdb/make_fof.py
@@ -1,16 +1,17 @@
 import os
 
+from ..utils import ArgumentParser
+
 def get_taxa_id(path):
     c, n = os.path.basename(path).split('_')[0:2]
     return c + '_' + n
 
 
 def get_accessions(argv=None):
-    import argparse
     import pandas as pd
     import numpy as np
 
-    parser = argparse.ArgumentParser()
+    parser = ArgumentParser()
     parser.add_argument('metadata', type=str, help='metadata file from GTDB')
     rep_grp = parser.add_mutually_exclusive_group()
     rep_grp.add_argument('-r', '--rep', action='store_true', default=False, help='keep representative genomes only. keep both by default')
@@ -49,7 +50,6 @@ def get_accessions(argv=None):
 
 def make_fof(argv=None):
     '''Find files and print paths for accessions'''
-    import argparse
     import logging
     import sys
     import glob
@@ -61,8 +61,8 @@ def make_fof(argv=None):
 
 
     epi = "fadir should be organized with the same structure as the NCBI FTP site"
-    parser = argparse.ArgumentParser(epilog=epi)
-    parser.add_argument('fadir', type=str, help='directory with NCBI sequence files')
+    parser = ArgumentParser(epilog=epi)
+    parser.add_argument('fadir', type=str, help='directory with NCBI sequence files. This is the directory that contains the \'all\' directory')
     parser.add_argument('accessions', type=str, help='A file containing accessions')
     parser.add_argument('-t', '--tree', action='store_true', default=False, help='accessions are from a tree in Newick format')
     parser.add_argument('-f', '--hdmf_file', action='store_true', default=False, help='get accessions from a DeepIndex HDMF file')
@@ -134,6 +134,75 @@ def make_fof(argv=None):
             func = get_faa_path
         for line in accessions:
             print(func(line.strip(), args.fadir), file=sys.stdout)
+
+
+def split_fof(argv=None):
+
+    import sys
+    import multiprocessing as mp
+
+    import numpy as np
+    from tqdm import tqdm
+
+    from ..utils import balsplit, path_size
+
+    parser = ArgumentParser()
+    parser.add_argument("fof", help="the file of files to split")
+    parser.add_argument("n_splits", type=int, help="the number of split")
+    parser.add_argument("outbase", type=str, help="the basename for the files")
+    parser.add_argument("-p", "--n_procs", type=int, help="the number of processes to calculate file size", default=16)
+
+
+    args = parser.parse_args(args=argv)
+    pool = mp.Pool(args.n_procs)
+
+    print(f"Reading {args.fof} and calculating sizes")
+    paths = list()
+    sizes = list()
+    with open(args.fof, 'r') as f:
+        it = pool.imap(path_size, f, chunksize=1000)
+        for path, size in tqdm(it):
+            paths.append(path)
+            sizes.append(size)
+
+    paths = np.array(paths)
+    sizes = np.array(sizes)
+
+    print(f"Calculating split")
+    indices = balsplit(sizes, args.n_splits)
+
+    print(f"Writing splits")
+    for i in tqdm(range(args.n_splits)):
+        with open(f"{args.outbase}.{i:04}.fof", "w") as f:
+            for path in paths[indices[i]]:
+                print(path, file=f)
+
+
+def append_accessions(argv=None):
+    import sys
+
+    from skbio import DNA
+    import skbio.io as skio
+
+    desc = "fasta_path must be a file path from NCBI and have the genome assembly accession in it"
+    parser = ArgumentParser(description=desc)
+    parser.add_argument('fasta_path', type=str, help='the fasta file to append the prefix to')
+
+    args = parser.parse_args(args=argv)
+    args.prefix = os.path.basename(args.fasta_path)[:15]
+
+    seqs = list()
+    tmp_fa = sys.stdout
+    w = 100
+    for seq in skio.read(args.fasta_path, format='fasta', constructor=DNA):
+        seq.metadata['id'] = args.prefix+"-"+str(len(seq))+"-"+seq.metadata['id']
+        seqs.append(seq)
+        tmp_fa.write('>')
+        tmp_fa.write(seq.metadata['id'])
+        tmp_fa.write('\n')
+        for s in range(0, len(seq), w):
+            tmp_fa.write(''.join(seq.values[s:s+w].astype('U')))
+            tmp_fa.write('\n')
 
 
 if __name__ == '__main__':

--- a/src/deep_taxon/nn/collaters.py
+++ b/src/deep_taxon/nn/collaters.py
@@ -14,7 +14,7 @@ class SplitCollater:
         l_idx = -1
         if isinstance(samples, tuple):
             samples = [samples]
-        for i, X, y, seq_id in samples:
+        for i, X, y, seq_id, genome in samples:
             if maxlen < X.shape[l_idx]:
                 maxlen = X.shape[l_idx]
         X_ret = list()
@@ -22,7 +22,8 @@ class SplitCollater:
         idx_ret = list()
         size_ret = list()
         seq_id_ret = list()
-        for i, X, y, seq_id in samples:
+        genome_ret = list()
+        for i, X, y, seq_id, genome in samples:
             dif = maxlen - X.shape[l_idx]
             X_ = X
             if dif > 0:
@@ -32,14 +33,16 @@ class SplitCollater:
             size_ret.append(X.shape[l_idx])
             idx_ret.append(i)
             seq_id_ret.append(seq_id)
+            genome_ret.append(genome)
         X_ret = torch.stack(X_ret)
         y_ret = torch.stack(y_ret)
         size_ret = torch.tensor(size_ret)
         idx_ret = torch.tensor(idx_ret)
         seq_id_ret = torch.tensor(seq_id_ret)
+        genome_ret = torch.tensor(genome_ret)
 
         if self.freq == 1.0 or rs.rand() < self.freq:
-            f = factors[rs.randint(len(factors))]
+            f = self.factors[rs.randint(len(self.factors))]
             y_ret = y_ret.repeat_interleave(f)
             seq_id_ret = seq_id_ret.repeat_interleave(f)
             idx_ret = idx_ret.repeat_interleave(f)
@@ -51,7 +54,7 @@ class SplitCollater:
             bad_chunk_pos = torch.where(n_bad_chunks > 0)[0]
             start_bad_chunks = bad_chunk_pos + q[bad_chunk_pos]
 
-        return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret)
+        return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret, genome_ret)
 
 
 class SeqCollater:
@@ -64,7 +67,7 @@ class SeqCollater:
         l_idx = -1
         if isinstance(samples, tuple):
             samples = [samples]
-        for i, X, y, seq_id in samples:
+        for i, X, y, seq_id, genome in samples:
             if maxlen < X.shape[l_idx]:
                 maxlen = X.shape[l_idx]
         X_ret = list()
@@ -72,7 +75,8 @@ class SeqCollater:
         idx_ret = list()
         size_ret = list()
         seq_id_ret = list()
-        for i, X, y, seq_id in samples:
+        genome_ret = list()
+        for i, X, y, seq_id, genome in samples:
             dif = maxlen - X.shape[l_idx]
             X_ = X
             if dif > 0:
@@ -82,6 +86,7 @@ class SeqCollater:
             size_ret.append(X.shape[l_idx])
             idx_ret.append(int(i))
             seq_id_ret.append(int(seq_id))
+            genome_ret.append(int(genome))
         X_ret = torch.stack(X_ret)
         y_ret = torch.stack(y_ret)
         size_ret = torch.tensor(size_ret)
@@ -101,12 +106,12 @@ class TrainingSeqCollater:
         l_idx = -1
         if isinstance(samples, tuple):
             samples = [samples]
-        for i, X, y, seq_id in samples:
+        for i, X, y, seq_id, genome_id in samples:
             if maxlen < X.shape[l_idx]:
                 maxlen = X.shape[l_idx]
         X_ret = list()
         y_ret = list()
-        for i, X, y, seq_id in samples:
+        for i, X, y, seq_id, genome_id in samples:
             dif = maxlen - X.shape[l_idx]
             X_ = X
             if dif > 0:
@@ -233,7 +238,7 @@ class TnfCollater:
             samples = [samples]
 
         maxlen = 0
-        for i, X, y, seq_id in samples:
+        for i, X, y, seq_id, genome in samples:
             if maxlen < X.shape[l_idx]:
                 maxlen = X.shape[l_idx]
 
@@ -242,7 +247,8 @@ class TnfCollater:
         idx_ret = list()
         size_ret = list()
         seq_id_ret = list()
-        for i, X, y, seq_id in samples:
+        genome_ret = list()
+        for i, X, y, seq_id, genome in samples:
             dif = maxlen - X.shape[l_idx]
             X_ = X
             if dif > 0:
@@ -252,6 +258,7 @@ class TnfCollater:
             size_ret.append(X.shape[l_idx])
             idx_ret.append(i)
             seq_id_ret.append(seq_id)
+            genome_ret.append(genome)
 
         # calculate tetranucleotide frequency
         chunks = torch.stack(X_ret)

--- a/src/deep_taxon/nn/collaters.py
+++ b/src/deep_taxon/nn/collaters.py
@@ -92,7 +92,8 @@ class SeqCollater:
         size_ret = torch.tensor(size_ret)
         idx_ret = torch.tensor(idx_ret)
         seq_id_ret = torch.tensor(seq_id_ret)
-        return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret)
+        genome_ret = torch.tensor(genome_ret)
+        return (idx_ret, X_ret, y_ret, size_ret, seq_id_ret, genome_ret)
 
 
 class TrainingSeqCollater:

--- a/src/deep_taxon/nn/infer.py
+++ b/src/deep_taxon/nn/infer.py
@@ -180,7 +180,8 @@ def process_args(args, comm=None):
         model.hparams.step = model.hparams.window
 
     if size > 1:
-        dataset = LazySeqDataset(difile=args.difile, hparams=argparse.Namespace(**model.hparams), keep_open=True, comm=comm, size=size, rank=rank)
+        dataset = LazySeqDataset(difile=args.difile, hparams=argparse.Namespace(**model.hparams),
+                                 keep_open=True, comm=comm, size=size, rank=rank, bal_gnm=True)
     else:
         dataset = LazySeqDataset(difile=args.difile, hparams=argparse.Namespace(**model.hparams), keep_open=True)
 
@@ -312,6 +313,105 @@ def _compute_mean(idx, outputs_q, counts_q):
     for oq in outputs_q:
         for i in range(len(idx)):
             oq[i] /= counts_q[i]
+
+def _reduce_chunks(labels_tt, ids, outputs, chunk_labels):
+    """ Reduce outputs and labels for each item
+
+    Args:
+        labels_tt:  the integerized taxonomy table
+        ids:        the ids for each chunk
+        outputs:    the output for each chunk
+
+    Returns:
+        items:          the unique items from *ids*
+        counts:         the number of occurence of each unique item in *ids*
+        outputs_sum:    the reduced output for each unique item
+        labels:         the label for each item
+    """
+    values, counts = np.unique(ids, return_counts=True)
+    outputs_sum = [[] for i in range(len(outputs))]
+    labels = list()
+    for i in values:
+        mask = ids == i
+        for o_sum, _output in zip(outputs_sum, outputs):
+            o_sum.append(_output[mask].sum(axis=0))
+        labels.append(labels_tt[chunk_labels[mask][0]])
+    return values, counts, outputs_sum, labels
+
+
+def _update_queues(items_q, items, outputs_q, outputs_sum, counts_q, counts, labels_q, labels):
+    """Update queues
+    Args:
+        items_q:        the IDs of the items in queue
+        items:          the IDs of the items at this iteration
+        outputs_q:      the outputs of the items in the queue
+        outputs_sum:    the reduced outputs for the chunks of each items at this iteration
+        counts_q:       the number of chunks that have gone into each item in the queue
+        counts:         the number of chunks for each item at this iteration
+        labels_q:       the labels of each item in the queue
+        labels:         the labels for each item at this iteration
+    """
+    # Add the first sum of this iteration to the last sum of
+    # the previous iteration if they belong to the same sequence
+    if len(items_q) > 0 and items_q[-1] == items[0]:
+        for oq, osum in zip(outputs_q, outputs_sum):
+            oq[-1] += osum[0]
+        counts_q[-1] += counts[0]
+        # drop the first sum so we don't end up with duplicates
+        items = items[1:]
+        counts = counts[1:]
+        outputs_sum = [osum[1:] for osum in outputs_sum]
+        labels = labels[1:]
+
+    for oq, osum in zip(outputs_q, outputs_sum):
+        oq.extend(osum)
+    items_q.extend(items)
+    counts_q.extend(counts)
+    labels_q.extend(labels)
+
+def _flush_queues(args, labels_tt, items_q, outputs_q, counts_q, maxprobs_dset, preds_dset, labels_q, labels_dset, final=False):
+    """Empty queues
+    Args:
+        args:           the args from parallel_chunked_inf_summ
+        labels_tt:      the integerized taxonomy table
+        items_q:        the IDs of the items in queue
+        outputs_q:      the outputs of the items in the queue
+        counts_q:       the number of chunks that have gone into each item in the queue
+        maxprobs_dset:  the dataset to write maxprobabilities to
+        preds_dset:     the dataset to write predictions to
+        labels_q:       the labels of each item in the queue
+        labels_dset:    the dataset to write labels to
+        final:          True if this is the final flush of the queues, False otherwise
+    """
+    # do not write the last sequence in case
+    # there are more chunks left for it
+    if final:
+        idx = items_q
+    else:
+        idx = items_q[:-1]
+
+
+    n_levels = labels_tt.shape[1]
+
+    _compute_mean(idx, outputs_q, counts_q)
+
+    labels_dset[idx] = labels_q if final else labels_q[:-1]
+
+    if args.hierarchy:
+        _write_hier_maxprobs(idx, outputs_q, n_levels, args.maxprob, labels_tt, maxprobs_dset, preds_dset)
+    else:
+        _write_maxprobs(idx, outputs_q, n_levels, args.maxprob, maxprobs_dset)
+        _write_preds(idx, outputs_q, n_levels, args.maxprob, preds_dset)
+
+    # drop everything except for the last sequence
+    # in case there are more chunks left for it
+    for oq in outputs_q:
+        del oq[:-1]
+    del items_q[:-1]
+    del counts_q[:-1]
+    del labels_q[:-1]
+
+    return idx
 ### END: Helper functions for parallel_chunked_inf_summ
 
 
@@ -324,31 +424,24 @@ def parallel_chunked_inf_summ(model, dataset, loader, args, fkwargs, tt):
     args.logger.debug(f"rank {dataset.rank} - n_samples = {n_samples}")
     all_seq_ids = dataset.difile.id #get_sequence_subset()
     seq_lengths  = dataset.difile.lengths #get_seq_lengths()
+    all_gnm_ids = np.unique(dataset.difile.genomes)
 
     f = h5py.File(args.output, 'w', **fkwargs)
     outputs_dset = None
     if args.save_chunks:
         outputs_dset = f.require_dataset('outputs', shape=(n_samples, args.n_outputs), dtype=float)
+
+    # Set up datasets for sequences
+    seq_grp = f.create_group("sequences")
     args.logger.debug(f"rank {dataset.rank} - making labels")
-    labels_dset = f.require_dataset('labels', shape=(n_samples, n_levels), dtype=int, fillvalue=-1)
+    labels_dset = seq_grp.require_dataset('labels', shape=(n_samples, n_levels), dtype=int, fillvalue=-1)
     labels_dset.attrs['n_classes'] = args.n_outputs
-
     args.logger.debug(f"rank {dataset.rank} - making maxprob")
-    maxprob_dset = f.require_dataset('maxprob', shape=(n_samples, n_levels, args.maxprob), dtype=float)
-
+    maxprobs_dset = seq_grp.require_dataset('maxprob', shape=(n_samples, n_levels, args.maxprob), dtype=float)
     args.logger.debug(f"rank {dataset.rank} - making preds")
-    preds_dset = f.require_dataset('preds', shape=(n_samples, n_levels,), dtype=int, fillvalue=-1)
+    preds_dset = seq_grp.require_dataset('preds', shape=(n_samples, n_levels,), dtype=int, fillvalue=-1)
     args.logger.debug(f"rank {dataset.rank} - making lengths")
-    seqlen_dset = f.require_dataset('lengths', shape=(n_samples,), dtype=int, fillvalue=-1)
-    args.logger.debug(f"rank {dataset.rank} - making lengths")
-    genomes_dset = f.require_dataset('genomes', shape=(n_samples,), dtype=int, fillvalue=-1)
-
-    levels_dset = f.create_dataset('levels', shape=(n_levels,), dtype=levels.dtype)
-    rank = 0
-    if 'comm' in fkwargs:
-        fkwargs['comm'].Get_rank()
-    if rank == 0:
-        levels_dset[:] = levels
+    seqlen_dset = seq_grp.require_dataset('lengths', shape=(n_samples,), dtype=int, fillvalue=-1)
 
     if all_seq_ids is None:
         seqlen_dset[:] = seq_lengths
@@ -358,15 +451,49 @@ def parallel_chunked_inf_summ(model, dataset, loader, args, fkwargs, tt):
         for i in range(len(seq_lengths)):
             seqlen_dset[all_seq_ids[i]] = seq_lengths[i]
 
+    gnm_grp = f.create_group("genomes")
+
+    args.logger.debug(f"rank {dataset.rank} - making labels")
+    gnm_labels_dset = gnm_grp.require_dataset('labels', shape=(n_samples, n_levels), dtype=int, fillvalue=-1)
+    gnm_labels_dset.attrs['n_classes'] = args.n_outputs
+    args.logger.debug(f"rank {dataset.rank} - making maxprob")
+    gnm_maxprobs_dset = gnm_grp.require_dataset('maxprob', shape=(n_samples, n_levels, args.maxprob), dtype=float)
+    args.logger.debug(f"rank {dataset.rank} - making preds")
+    gnm_preds_dset = gnm_grp.require_dataset('preds', shape=(n_samples, n_levels,), dtype=int, fillvalue=-1)
+    args.logger.debug(f"rank {dataset.rank} - making lengths")
+    gnmlen_dset = gnm_grp.require_dataset('lengths', shape=(n_samples,), dtype=int, fillvalue=-1)
+    gnm_lengths = np.bincount(dataset.difile.genomes, weights=dataset.difile.lengths)
+
+    if all_seq_ids is None:
+        gnmlen_dset[:] = gnm_lengths
+    else:
+        gnm_lengths = gnm_lengths[all_gnm_ids]
+        args.logger.debug(f"rank {dataset.rank} - writing gnm_lengths")
+        # iterate over indices individually - passing this off to h5py takes prohibitively long
+        for gnm_i, gnm_len in zip(all_gnm_ids, gnm_lengths):
+            gnmlen_dset[gnm_i] = gnm_len
+
+
+    levels_dset = f.create_dataset('levels', shape=(n_levels,), dtype=levels.dtype)
+    rank = 0
+    if 'comm' in fkwargs:
+        fkwargs['comm'].Get_rank()
+    if rank == 0:
+        levels_dset[:] = levels
 
     # to-write queues - we use those so we're not doing I/O at every iteration
     outputs_q = [[] for i in range(len(transforms) + 1)]
+    gnm_outputs_q = [[] for i in range(len(transforms) + 1)]
     labels_q = list()
+    gnm_labels_q = list()
     counts_q = list()
+    gnm_counts_q = list()
     seqs_q = list()
     genomes_q = list()
 
-    labels_tt = tt.iloc[:, 1:].values
+    labels_tt = tt.iloc[:, 1:]
+    labels_tt['species'] = np.arange(len(labels_tt))
+    labels_tt = labels_tt.values
 
     # write what's in the to-write queues
     if not hasattr(args, 'n_seqs'):
@@ -383,82 +510,46 @@ def parallel_chunked_inf_summ(model, dataset, loader, args, fkwargs, tt):
 
     for idx, _outputs, _labels, _orig_lens, _seq_ids, _genome_ids in get_outputs(*go_args, **go_kwargs):
 
-        seqs, counts = np.unique(_seq_ids, return_counts=True)
-        outputs_sum = [[] for i in range(len(_outputs))]
-        labels = list()
-        genomes = list()
-        for i in seqs:
-            mask = _seq_ids == i
-            for o_sum, _output in zip(outputs_sum, _outputs):
-                o_sum.append(_output[mask].sum(axis=0))
-            labels.append(labels_tt[_labels[mask][0]])
-            genomes.append(_genome_ids[mask][0])
         uniq_labels.update(_labels)
 
-        # Add the first sum of this iteration to the last sum of the
-        # previous iteration if they belong to the same sequence
-        if len(seqs_q) > 0 and seqs_q[-1] == seqs[0]:
-            for oq, osum in zip(outputs_q, outputs_sum):
-                oq[-1] += osum[0]
-            counts_q[-1] += counts[0]
-            # drop the first sum so we don't end up with duplicates
-            seqs = seqs[1:]
-            counts = counts[1:]
-            outputs_sum = [osum[1:] for osum in outputs_sum]
-            labels = labels[1:]
-            genomes = genomes[1:]
+        # sum the outputs of the chunks for each sequence
+        seqs, counts, outputs_sum, labels = _reduce_chunks(labels_tt, _seq_ids, _outputs, _labels)
 
-        for oq, osum in zip(outputs_q, outputs_sum):
-            oq.extend(osum)
-        seqs_q.extend(seqs)
-        counts_q.extend(counts)
-        labels_q.extend(labels)
-        genomes_q.extend(genomes)
+        # sum the outputs of the chunks for each genome
+        genomes, gnm_counts, gnm_outputs_sum, gnm_labels = _reduce_chunks(labels_tt, _genome_ids, _outputs, _labels)
 
-        # write when we get above a certain number of sequences
+        # update the queues for each sequence
+        _update_queues(seqs_q, seqs, outputs_q, outputs_sum, counts_q, counts, labels_q, labels)
+
+        # update the queues for each genome
+        _update_queues(genomes_q, genomes, gnm_outputs_q, gnm_outputs_sum, gnm_counts_q, gnm_counts, gnm_labels_q, gnm_labels)
+
+        # flush the sequences queues once we have more than specified
         if len(seqs_q) > args.n_seqs:
-            # do not write the last sequence in case
-            # there are more chunks left for it
-            idx = seqs_q[:-1]
+            idx = _flush_queues(args, labels_tt, seqs_q,
+                                outputs_q, counts_q, maxprobs_dset, preds_dset,
+                                labels_q, labels_dset)
             args.logger.debug(f"rank {dataset.rank} - saving these sequences {idx}")
 
-            _compute_mean(idx, outputs_q, counts_q)
+        # flush the genomes queues once we have more than specified
+        if len(genomes_q) > args.n_seqs:
+            idx = _flush_queues(args, labels_tt, genomes_q,
+                                gnm_outputs_q, gnm_counts_q, gnm_maxprobs_dset, gnm_preds_dset,
+                                gnm_labels_q, gnm_labels_dset)
+            args.logger.debug(f"rank {dataset.rank} - saving these genomes {idx}")
 
-            if outputs_dset is not None:
-                for i in range(len(outputs_dset)):
-                    outputs_dset[i][idx] = outputs_q[i][:-1]
-            labels_dset[idx] = labels_q[:-1]
-            genomes_dset[idx] = genomes_q[:-1]
-
-
-            if args.hierarchy:
-                _write_hier_maxprobs(idx, outputs_q, n_levels, args.maxprob, labels_tt, maxprob_dset, preds_dset)
-            else:
-                _write_maxprobs(idx, outputs_q, n_levels, args.maxprob, maxprob_dset)
-                _write_preds(idx, outputs_q, n_levels, args.maxprob, preds_dset)
-
-
-            # drop everything except for the last sequence
-            # in case there are more chunks left for it
-            outputs_q = [oq[-1:] for oq in outputs_q]
-            seqs_q = seqs_q[-1:]
-            counts_q = counts_q[-1:]
-            labels_q = labels_q[-1:]
-            genomes_q = genomes_q[-1:]
-
-    args.logger.debug(f"rank {dataset.rank} - saving these sequences {seqs_q}")
     args.logger.debug(f"rank {dataset.rank} - came across these labels {list(sorted(uniq_labels))}")
     # clean up what's left in the to-write queue
-    _compute_mean(seqs_q, outputs_q, counts_q)
 
-    labels_dset[seqs_q] = labels_q
-    genomes_dset[seqs_q] = genomes_q
+    idx = _flush_queues(args, labels_tt, seqs_q,
+                        outputs_q, counts_q, maxprobs_dset, preds_dset,
+                        labels_q, labels_dset, final=True)
+    args.logger.debug(f"rank {dataset.rank} - saving these sequences {idx}")
 
-    if args.hierarchy:
-        _write_hier_maxprobs(seqs_q, outputs_q, n_levels, args.maxprob, labels_tt, maxprob_dset, preds_dset)
-    else:
-        _write_maxprobs(seqs_q, outputs_q, n_levels, args.maxprob, maxprob_dset)
-        _write_preds(seqs_q, outputs_q, n_levels, args.maxprob, preds_dset)
+    idx = _flush_queues(args, labels_tt, genomes_q,
+                        gnm_outputs_q, gnm_counts_q, gnm_maxprobs_dset, gnm_preds_dset,
+                        gnm_labels_q, gnm_labels_dset, final=True)
+    args.logger.debug(f"rank {dataset.rank} - saving these genomes {idx}")
 
     args.logger.info(f'rank {dataset.rank} - closing {args.output}')
     f.close()
@@ -528,13 +619,13 @@ def get_outputs(model, loader, device, debug=False, chunks=None, prog_bar=True, 
             if idx >= max_batches:
                 break
             if chunks and (idx+1) % chunks == 0:
-                yield cat(indices, outputs, labels, orig_lens, seq_ids)
+                yield cat(indices, outputs, labels, orig_lens, seq_ids, genomes)
                 indices, outputs, labels, orig_lens, seq_ids, genomes = [], [[] for i in range(n_levels)], [], [], [], []
     if chunks is None:
-        return cat(indices, outputs, labels, orig_lens, seq_ids, genome)
+        return cat(indices, outputs, labels, orig_lens, seq_ids, genomes)
     else:
         if len(indices) > 0:
-            yield cat(indices, outputs, labels, orig_lens, seq_ids, genome)
+            yield cat(indices, outputs, labels, orig_lens, seq_ids, genomes)
 
 
 def cat(indices, outputs, labels, orig_lens, seq_ids, genome):

--- a/src/deep_taxon/nn/loader.py
+++ b/src/deep_taxon/nn/loader.py
@@ -805,10 +805,11 @@ class LazySeqDataset(Dataset):
         seq = item['seq']
         label = item['label']
         seq_id = item.get('seq_idx', -1)
+        genome_id = item.get('genome', -1)
         ## one-hot encode sequence
         #seq = torch.as_tensor(seq, dtype=torch.int64)
         seq = torch.as_tensor(seq)
         if self.__ohe:
             seq = F.one_hot(seq, num_classes=len(self.difile.vocab)).float()
         label = torch.as_tensor(label, dtype=self._label_dtype)
-        return (idx, seq, label, seq_id)
+        return (idx, seq, label, seq_id, genome)

--- a/src/deep_taxon/nn/loader.py
+++ b/src/deep_taxon/nn/loader.py
@@ -613,6 +613,7 @@ class LazySeqDataset(Dataset):
         kwargs.setdefault('tnf', False)
         kwargs.setdefault('weighted', None)
         kwargs.setdefault('shm', False)
+        kwargs.setdefault('bal_gnm', False)
 
         self.comm = kwargs.pop('comm', None)
 
@@ -691,7 +692,8 @@ class LazySeqDataset(Dataset):
                                               tree_graph=tree_graph,
                                               load=kwargs['load'],
                                               shm=kwargs['shm'],
-                                              indices=seq_indices)
+                                              indices=seq_indices,
+                                              bal_gnm = kwargs['bal_gnm'])
         self._set_subset(train=self._train_subset, validate=self._validate_subset, test=self._test_subset)
 
         self.__len = len(self.difile)
@@ -812,4 +814,4 @@ class LazySeqDataset(Dataset):
         if self.__ohe:
             seq = F.one_hot(seq, num_classes=len(self.difile.vocab)).float()
         label = torch.as_tensor(label, dtype=self._label_dtype)
-        return (idx, seq, label, seq_id, genome)
+        return (idx, seq, label, seq_id, genome_id)

--- a/src/deep_taxon/nn/summarize.py
+++ b/src/deep_taxon/nn/summarize.py
@@ -1099,12 +1099,6 @@ def _write_skorch(model, lvl, outdir, logger):
     return path
 
 
-def _to_onnx(model):
-    initial_type = [('float_input', FloatTensorType([None, model.coef_.shape[1]]))]
-    onx = convert_sklearn(model, target_opset=12, initial_types=initial_type, options={type(model): {'zipmap': False}})
-    return onx.SerializeToString().hex()
-
-
 def _write_model(model, basename, outdir, onnx, logger, n_inputs):
     if onnx:
         output_path = os.path.join(outdir, f'{basename}.onnx')

--- a/src/deep_taxon/nn/summarize.py
+++ b/src/deep_taxon/nn/summarize.py
@@ -17,7 +17,6 @@ import scipy.stats as stats
 #from skl2onnx import convert_sklearn
 #from skl2onnx.common.data_types import FloatTensorType
 import pickle
-import sk2torch
 
 from sklearn.linear_model import LogisticRegression, LogisticRegressionCV, SGDClassifier
 from sklearn.dummy import DummyClassifier
@@ -1017,30 +1016,6 @@ def add_diff(_X):
     diff = _X[:, 1] - _X[:, 2]
     return np.concatenate([_X, diff[:, np.newaxis]], axis=1)
 
-def _fit_model(maxprobs, lengths, true, pred, cvs, n_jobs, logger, debug):
-    maxprobs  = maxprobs[:, :2]
-    X = np.concatenate([lengths[:, np.newaxis], maxprobs], axis=1)
-    diff_tfm = FunctionTransformer(add_diff)
-    scaler = MaxAbsScaler()
-
-    if debug:
-        lr = DummyClassifier(strategy="prior")
-    else:
-        lr = SGDClassifier(loss='log_loss', early_stopping=True, validation_fraction=0.1,
-                             class_weight='balanced', alpha=1.0, learning_rate='adaptive', eta0=0.01)
-
-
-    pipe = Pipeline([('add_diff', diff_tfm),
-                     ('scaler', scaler),
-                     ('lm', lr)])
-
-    y = (true == pred).astype(int)
-
-    logger.info(f"Building confidence model with \n{lr}")
-    pipe.fit(X, y)
-
-    return pipe, X, y
-
 
 class LogisticRegression(nn.Module):
 
@@ -1051,7 +1026,7 @@ class LogisticRegression(nn.Module):
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
-        diff = x[:, 1] - x[:, 2]
+        diff = x[:, -2] - x[:, -1]
         x = torch.column_stack([x, diff])
         x = self.norm(x)
         x = self.weights(x)
@@ -1082,11 +1057,11 @@ class MyNet(skorch.NeuralNetBinaryClassifier):
         return loss_reduced
 
 
-def _fit_skorch(maxprobs, lengths, true, pred, cvs, n_jobs, logger, debug):
+def _fit_skorch(maxprobs, features, true, pred, logger, debug):
     maxprobs  = maxprobs[:, :2]
-    X = np.concatenate([lengths[:, np.newaxis], maxprobs], axis=1).astype(np.float32)
+    X = np.concatenate([features, maxprobs], axis=1).astype(np.float32)
     X = torch.from_numpy(X)
-    y = torch.from_numpy((true == pred).astype(np.int32))
+    y = torch.from_numpy((true == pred).astype(int))
 
     if debug:
         X = X[:1024]
@@ -1095,6 +1070,7 @@ def _fit_skorch(maxprobs, lengths, true, pred, cvs, n_jobs, logger, debug):
     sample_weight = (X.shape[0] / (2 * torch.bincount(y, minlength=2)))[y]
     y = y.float()
 
+    n_inputs = X.shape[1]
     X = {'data': X, 'sample_weight': sample_weight}
 
     with tempfile.TemporaryDirectory(dir='.') as d:
@@ -1104,7 +1080,8 @@ def _fit_skorch(maxprobs, lengths, true, pred, cvs, n_jobs, logger, debug):
                      max_epochs=10,
                      callbacks=[skorch.callbacks.Checkpoint(monitor='valid_acc_best',
                                            dirname=d, load_best=True)],
-                     iterator_train__shuffle=True)
+                     iterator_train__shuffle=True,
+                     module__n_inputs=n_inputs)
 
         logger.info(f"Building confidence model with \n{pipe}")
         pipe.fit(X, y)
@@ -1156,39 +1133,52 @@ def train_confidence_model(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("output_dir", type=str, help="the directory to save models to")
     parser.add_argument("summary", type=str, help='the summarized sequence NN outputs', nargs='?')
-    parser.add_argument('-O', '--onnx', default=False, action='store_true', help='Save data in ONNX format')
     parser.add_argument("-k", "--topk", metavar="TOPK", type=int, help="use the TOPK probabilities for building confidence model", default=None)
-    parser.add_argument('-j', '--n_jobs', metavar='NJOBS', nargs='?', const=True, default=None, type=int,
-                        help='the number of jobs to use for cross-validation. if NJOBS is not specified, use the number of folds i.e. 5')
-    parser.add_argument('-c', '--cvs', metavar='NFOLDS', default=5, type=int,
-                        help='the number of cross-validation folds to use. default is 5')
+    parser.add_argument("-b", "--bins", action='store_true', default=False,
+                        help='compute confidence models for bins/genomes. By default, build models for contigs/sequences')
     parser.add_argument("-e", "--eval", action='store_true', help='evaluate the train confidence model', default=False)
     parser.add_argument("-f", "--force", action='store_true', help='force training i.e. do not use output if it exists', default=False)
     parser.add_argument("-d", "--debug", action='store_true', help='Run workflow without training models', default=False)
 
     args = parser.parse_args(argv)
 
-    if args.n_jobs and isinstance(args.n_jobs, bool):
-        args.n_jobs = args.cvs
 
     logger = get_logger()
 
     X, y = None, None
     levels = None
 
+    features = None
     if args.summary:
         # train a new model
-        logger.info(f"Reading outputs summary data from {args.summary}")
         f = h5py.File(args.summary, 'r')
-
         levels = f['levels'].asstr()[:]
+        if args.bins:
+            logger.info(f"Training confidence models for bins")
+            logger.info(f"Reading genome summary data from {args.summary}")
+            grp = f['genomes']
+            true = grp['labels'][:]
+            pred = grp['preds'][:]
 
-        true = f['labels'][:]
-        pred = f['preds'][:]
+            # the top-k probabilities, in descending order
+            maxprobs = grp['maxprob'][:, :, :args.topk]
 
-        # the top-k probabilities, in descending order
-        maxprobs = f['maxprob'][:, :, :args.topk]
-        lengths = f['lengths'][:]
+            # get assembly statistics
+            grp = grp['asm_stats']
+            features = np.column_stack([grp['n_ctgs'], grp['l50'], grp['max_len']])
+
+        else:
+            logger.info(f"Training confidence models for contigs")
+            logger.info(f"Reading sequence summary data from {args.summary}")
+            grp = f['sequences']
+            true = grp['labels'][:]
+            pred = grp['preds'][:]
+
+            # the top-k probabilities, in descending order
+            maxprobs = grp['maxprob'][:, :, :args.topk]
+
+            # get sequence length
+            features = grp['lengths'][:][:, np.newaxis]
 
         f.close()
 
@@ -1196,14 +1186,6 @@ def train_confidence_model(argv=None):
 
     if os.path.exists(args.output_dir) and not args.force:
         logger.info(f"Found existing directory at {args.output_dir}. Exiting. (Use --force to override)")
-        #for pkl in glob.glob(f"{args.output_dir}/*.pkl"):
-        #    with open(pkl, 'rb') as f:
-        #        lr = pickle.load(f)
-        #    lvl = os.path.splitext(os.path.basename(pkl))[0]
-        #    models[lvl] = lr
-        #    if args.onnx:
-        #        logger.info(f"Converting {lvl}-level model found in {pkl} to ONNX format")
-        #        _write_model(lr, lvl, args.output_dir, True, logger)
 
     else:
         os.makedirs(args.output_dir, exist_ok=args.force)
@@ -1218,11 +1200,8 @@ def train_confidence_model(argv=None):
         for lvl_i, lvl in enumerate(levels):
             lvl = levels[lvl_i]
             logger.info(f"Building confidence model for {lvl}")
-            #lr, X, y = _fit_model(maxprobs[:, lvl_i], lengths, true[:, lvl_i], pred[:, lvl_i], args.cvs, args.n_jobs, logger, args.debug)
-            #n_inputs.append(X.shape[1])
-            #outpath = _write_model(lr, lvl, args.output_dir, False, logger, n_inputs[-1])
 
-            lr, X, y = _fit_skorch(maxprobs[:, lvl_i], lengths, true[:, lvl_i], pred[:, lvl_i], args.cvs, args.n_jobs, logger, args.debug)
+            lr, X, y = _fit_skorch(maxprobs[:, lvl_i], features, true[:, lvl_i], pred[:, lvl_i], logger, args.debug)
             n_inputs.append(X['data'].shape[1])
 
             logger.info(f"Evaluating {lvl} model")

--- a/src/deep_taxon/nn/train.py
+++ b/src/deep_taxon/nn/train.py
@@ -26,7 +26,8 @@ from pytorch_lightning import Trainer as PLTrainer, seed_everything
 from pytorch_lightning.loggers import CSVLogger
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, StochasticWeightAveraging, LearningRateMonitor, DeviceStatsMonitor, TQDMProgressBar
 
-from pytorch_lightning.profiler import PyTorchProfiler
+from pytorch_lightning.profilers import PyTorchProfiler
+
 
 from pytorch_lightning.plugins.environments import SLURMEnvironment, LSFEnvironment
 try:
@@ -551,6 +552,7 @@ def run_lightning(argv=None):
                                          mode=mode,
                                          monitor=monitor))
         if args.timed_checkpoint:
+            monitor, mode = (AbstractLit.train_loss, 'min') if (args.manifold or args.umap) else (AbstractLit.train_acc, 'max')
             if isinstance(args.timed_checkpoint, str):
                 args.timed_checkpoint = int(args.timed_checkpoint)
             else:
@@ -562,7 +564,8 @@ def run_lightning(argv=None):
                                              train_time_interval=timedelta(minutes=args.timed_checkpoint),
                                              save_top_k=12,
                                              save_last=True,
-                                             monitor=None))
+                                             mode=mode,
+                                             monitor=monitor))
 
     if args.early_stop:
         callbacks.append(EarlyStopping(monitor=monitor, min_delta=0.001, patience=10, verbose=False, mode=mode))

--- a/src/deep_taxon/run/job.py
+++ b/src/deep_taxon/run/job.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import sys
 from abc import abstractmethod, ABCMeta
 from collections import OrderedDict
 
@@ -83,6 +84,7 @@ class AbstractJob(metaclass=ABCMeta):
         self.jobname = kwargs.get('jobname')
         self.nodes = kwargs.get('nodes')
         self.wait = kwargs.get('wait')
+        self.cmdline = kwargs.get('cmdline', " ".join(sys.argv))
         self.conda_env = None
         self.modules = list()
         self.debug = False
@@ -195,6 +197,8 @@ class AbstractJob(metaclass=ABCMeta):
     def write(self, f, options=None):
         self.write_header(f, options)
         print(file=f)
+        if self.cmdline is not None:
+            print(f"# {self.cmdline}", file=f)
         for var in self.clear_var:
             print(f"unset {var}", file=f)
         print(file=f)

--- a/src/deep_taxon/sequence/dna_table.py
+++ b/src/deep_taxon/sequence/dna_table.py
@@ -521,6 +521,8 @@ class DeepIndexFile(Container):
             # swap everything in
             log('Loading data subset - loading IDs', print_msg=verbose)
             self.seq_table['id'].transform(lambda x: x[:][self.__indices])
+            log('Loading data subset - loading genome IDs', print_msg=verbose)
+            self.seq_table['genome'].transform(lambda x: x[:][self.__indices])
             log('Loading data subset - swapping in lengths', print_msg=verbose)
             self.seq_table['length'].transform(lambda x: subset_lengths)
             log('Loading data subset - swapping in sequence index', print_msg=verbose)
@@ -533,6 +535,8 @@ class DeepIndexFile(Container):
             _load = lambda x: x.astype(int)[:]
             log('Loading data - loading IDs', print_msg=verbose)
             self.seq_table['id'].transform(_load)
+            log('Loading data - loading genome IDs', print_msg=verbose)
+            self.seq_table['genome'].transform(_load)
             log('Loading data - loading sequence lengths', print_msg=verbose)
             self.seq_table['length'].transform(_load)
             log('Loading data - loading sequence index', print_msg=verbose)
@@ -644,12 +648,12 @@ def chunk_sequence(difile, wlen, step=None, min_seq_len=100):
     return seq_idx, chunk_start, chunk_end, labels, mask.mean()
 
 
-def lazy_chunk_sequence(difile, wlen, step=None, min_seq_len=100):
+def lazy_chunk_sequence(lengths, wlen, step=None, min_seq_len=100):
     if wlen < min_seq_len:
         raise ValueError('window size (wlen) must be greater than or equal to minimum chunk length (min_seq_len)')
 
     # the length of each sequence
-    lengths = np.asarray(difile.get_seq_lengths(), dtype=int)
+    lengths = np.asarray(lengths, dtype=int)
 
     # C_min is the shortest chunk before filtering (for each sequence)
     C_min = lengths % step
@@ -693,7 +697,7 @@ class LazyWindowChunkedDIFile:
 
 
     def __init__(self, difile, window, step, min_seq_len=100, rank=0, size=1, revcomp=False, tree_graph=False, load=True, shm=False, indices=None):
-        counts, frac_good = lazy_chunk_sequence(difile, window, step, min_seq_len)
+        counts, frac_good = lazy_chunk_sequence(difile.get_seq_lengths(), window, step, min_seq_len)
         if size > 1 and indices is None:
             indices = balsplit(counts, size, rank)
         if indices is not None:
@@ -705,6 +709,8 @@ class LazyWindowChunkedDIFile:
         self.lengths = difile.seq_table['length'].data
         log('setting ids', print_msg=rank==0)
         self.id = difile.seq_table['id'].data
+        log('setting genomes', print_msg=rank==0)
+        self.genomes = difile.seq_table['genome'].data
         log('setting labels', print_msg=rank==0)
         self.labels = torch.from_numpy(difile._labels)  # store as torch Tensor since this is used for loss calculations
 
@@ -781,7 +787,8 @@ class LazyWindowChunkedDIFile:
         idx = self.id[arg]
         label = self.labels[arg]
         length = self.lengths[arg]
-        return {'id': idx, 'seq': seq, 'label': label, 'length': length}
+        genome = self.genomes[arg]
+        return {'id': idx, 'seq': seq, 'label': label, 'length': length, 'genome': genome}
 
     def get_label_classes(self):
         return self._classes

--- a/src/deep_taxon/utils.py
+++ b/src/deep_taxon/utils.py
@@ -191,3 +191,17 @@ def balsplit(weights, size, rank=None):
         return np.array(np.sort(ids[rank]))
     else:
         return [np.array(np.sort(ids[i])) for i in range(size)]
+
+
+def path_size(path):
+    path = path[:-1]
+    return (path, os.path.getsize(path))
+
+
+class ArgumentParser(argparse.ArgumentParser):
+
+    def __init__(self, prog=None, **kwargs):
+        kwargs.set_default('prog', f"{os.path.basename(sys.argv[0])} {sys.argv[1]}")
+        super().__init__(prog=prog, **kwargs)
+
+


### PR DESCRIPTION
- Update loader and assembly stats calculations for building bin confidence models
- Add bin and confidence models to deploy package
- Add `split-fof` and `append-accessions` command
  - These are used for setting up files for running CAT, Sourmash and GTNet
- Add custom ArgumentParser that prints subcommand in usage statement